### PR TITLE
Remove ToC and remove headings numbers

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,6 @@
+{
+    "MD013": false,
+    "MD024": {
+        "allow_different_nesting": true
+    }
+}

--- a/ConcurrentProgramming/README.md
+++ b/ConcurrentProgramming/README.md
@@ -1,44 +1,24 @@
 # Concurrent Programming <!-- omit in toc -->
 
-## Table of Contents <!-- omit in toc -->
+## Program life cycle
 
-- [1. Program life cycle](#1-program-life-cycle)
-  - [1.1. Design Time](#11-design-time)
-  - [1.2. Execution Time](#12-execution-time)
-- [2. Sequential Programming](#2-sequential-programming)
-  - [2.1. Introduction](#21-introduction)
-  - [2.2. Dependency Injection (DI)](#22-dependency-injection-di)
-  - [2.3. Inversion of Control (IoC)](#23-inversion-of-control-ioc)
-  - [2.4. GUI Interoperability (Reactive and Interactive User Interface)](#24-gui-interoperability-reactive-and-interactive-user-interface)
-  - [2.5. Program Entities Interoperability](#25-program-entities-interoperability)
-- [3. Concurrent programming](#3-concurrent-programming)
-  - [3.1. Introduction](#31-introduction)
-  - [3.2. Multithreading or concurrent programming](#32-multithreading-or-concurrent-programming)
-  - [3.3. Resource sharing](#33-resource-sharing)
-  - [3.4. Synchronization](#34-synchronization)
-  - [3.5. Communication](#35-communication)
-- [4. Distributed Programming - Network Nodes Communication (out of scope)](#4-distributed-programming---network-nodes-communication-out-of-scope)
-- [5. See also](#5-see-also)
-
-## 1. Program life cycle
-
-### 1.1. Design Time
+### Design Time
 
 At design time the computer program is developed to be compliant with a requirement specification. It includes selected algorithms implementation and testing. Implementation is a process of program text editing according to the selected programming language and development environment.
 
-### 1.2. Execution Time
+### Execution Time
 
 A computer program is always executed in a surrounding context called an execution platform, for example operating system. One of the operating systems' responsibilities is to protect computer programs from each other by running each program in its own process. If a program fails, only that process is affected; programs wrapped by other processes can continue to perform. As a result addresses in one process have no meaning in another process. In the managed environment, application domains (or logical processes) and contexts provide a similar level of isolation and security at less cost and with a greater ability to scale well than an operating-system process.
 
-## 2. Sequential Programming
+## Sequential Programming
 
-### 2.1. Introduction
+### Introduction
 
 This section provides examples related to executing program instructions (statements) one by one in the order defined in advance at design time. Only patterns vital for the concept of concurrent programming have been selected. The original execution sequence may change as the result of applying control instructions and implicit concurrent programming.
 
 It is worth stressing that in sequential programming concurrent programming is applied implicitly if ever.
 
-### 2.2. Dependency Injection (DI)
+### Dependency Injection (DI)
 
 It is a programming pattern where the abstraction paradigm defined as a part of the object-oriented programming concept is applied to provide an instance of a concrete type when the type is not visible or shall be not referred to for some reason. In other words, the `new` operator is not applicable to create an instance in a location where this instance is to be used. The lack of possibility to deal directly with the concrete type in concern or deliberate avoiding direct access to this type for some reasons shall be recognized as a problem to be solved.
 
@@ -49,14 +29,14 @@ Below there are selected reasons why a concrete type is not visible or shall not
 1. the type in concern will be defined later for some reason, for example, to avoid waiting for the final implementation when work is forked to be conducted simultaneously by independent developers
 1. the type in concern is defined out of the current solution, for example, it is a part of a plug-in
 
-### 2.3. Inversion of Control (IoC)
+### Inversion of Control (IoC)
 
 It is a programming pattern that may be used to describe calling unknown methods because their implementation is not or should not be visible in the location where they are to be called. The following examples show typical scenarios
 
 - an abstract method implemented elsewhere by a type that an instance is provided applying the dependency injection pattern
 - a delegate object wrapping set of methods assigned elsewhere to an event or delegate variable
 
-### 2.4. GUI Interoperability (Reactive and Interactive User Interface)
+### GUI Interoperability (Reactive and Interactive User Interface)
 
 **Interactive**:
 It is a user of a computer and computer user interface interoperability pattern where one party of this interoperability triggers an action and expects a reaction from the other one. An example of this kind of interoperability is a mouse clicking on a virtual button on the computer screen and expecting a reaction from the program responsible to render this button on the screen. According to the definition, it is a blocking relationship, hence the round trip latency should be minimized to keep the user interface responsive and react smoothly to the triggered action.
@@ -66,7 +46,7 @@ It is a user of a computer and computer user interface interoperability pattern 
 
 Because usually the GUI should be recognized as a critical section, its interoperability with any underlying activity must be synchronized. It depends on the framework used to implement the interoperability.
 
-### 2.5. Program Entities Interoperability
+### Program Entities Interoperability
 
 **Synchronous**:
 It is a programming pattern to describe an interaction between a programming entity and a method called by it where the method is executed synchronously. In other words, the further execution of the calling entity is postponed until the called one has been finished. The concurrent programming concept deliberately is not applicable to implement this relationship.
@@ -87,42 +67,41 @@ It is a programming pattern to describe an interaction between programming entit
 - DataObservable
 - TickEventArgs
 
-## 3. Concurrent programming
+## Concurrent programming
 
-### 3.1. Introduction
-
+### Introduction
 
 - **Concurrent programming**: performing operations as a result of nondeterministic events
 - **Parallel Programming**: simultaneous execution of program operations
 - **Real Time Programming**: the time must be taken into account as a factor determining the correctness of the program
 
-### 3.2. Multi-threading or concurrent programming
+### Multi-threading or concurrent programming
 
 Both terms are used to refer to the programming pattern that allows writing a program to execute operations at run time as a result of nondeterministic events. Concurrency is when multiple sequences of instructions are run in overlapping periods of time. In other words, the instructions sequence execution is undetermined in advance. Thread is a type that may be used to represent a sequence of instructions in this scenario.
 
 - RunMethodAsynchronously from mpostol/RealTime#33
 
-### 3.3. Resource sharing
+### Resource sharing
 
 - CriticalSectionExample
 
-### 3.4. Synchronization
+### Synchronization
 
 - Hoare's monitor concept - MFT
 
-### 3.5. Communication
+### Communication
 
 Real time library
 
-## 4. Distributed Programming - Network Nodes Communication (out of scope)
+## Distributed Programming - Network Nodes Communication (out of scope)
 
 **Interactive**: It is a communication pattern to describe an interaction between communicating entities where the selected one triggers sending a request and expects a response message from the another interconnected parties. If the triggered request is non-blocking the interaction is called asynchronous, otherwise it is call synchronous.
 
 **Reactive**: it is a communication pattern to describe an interaction between communicating entities where the selected one triggers sending a message and does not expects reaction from the others parties receiving it. The triggered message send action must be non-blocking, It means that the message sending action should last as short as possible. It is one to many nodes interconnection relationship.
 
-## 5. See also
+## See also
 
-- [Postół, M, IMPLEMENTATION OF MONITOR CONCEPT IN MODULA-2; 2004; DOI: 10.13140/RG.2.2.30414.54087](https://www.researchgate.net/publication/358308019_IMPLEMENTATION_OF_MONITOR_CONCEPT_IN_MODULA-2);
+- [Postół, M, IMPLEMENTATION OF MONITOR CONCEPT IN MODULA-2; 2004; DOI: 10.13140/RG.2.2.30414.54087](https://www.researchgate.net/publication/358308019_IMPLEMENTATION_OF_MONITOR_CONCEPT_IN_MODULA-2)
 - [Teaching of Programming (TP)](http://mpostol.github.io/TP/)
 - [Programming in Practice; GitHub repository containing set of examples targeting education purpose.](https://github.com/mpostol/TP)
 - [Real-Time Programming Helpers Library; GitHub repository](https://github.com/mpostol/RealTime)

--- a/InformationComputation/DependencyInjection/README.md
+++ b/InformationComputation/DependencyInjection/README.md
@@ -1,53 +1,29 @@
-# 1. Dependency Injection
+# Dependency Injection
 
-## Table of content <!-- omit in toc -->
-
-- [1. Dependency Injection](#1-dependency-injection)
-  - [1.1. Preface](#11-preface)
-  - [1.2. What's the Problem?](#12-whats-the-problem)
-    - [1.2.1. Main Topics](#121-main-topics)
-    - [1.2.2. Testing Program](#122-testing-program)
-    - [1.2.3. Dependence on Unknown Type](#123-dependence-on-unknown-type)
-  - [1.3. Library Example Description](#13-library-example-description)
-  - [1.4. Tasks](#14-tasks)
-  - [1.5. Testing](#15-testing)
-  - [1.6. Polymorphism](#16-polymorphism)
-  - [1.7. Polymorphism Implementation](#17-polymorphism-implementation)
-  - [1.8. Calling Abstract Method](#18-calling-abstract-method)
-  - [1.9. Command Line Application](#19-command-line-application)
-  - [1.10. User Interface Problems](#110-user-interface-problems)
-  - [1.11. Implementation in Library](#111-implementation-in-library)
-  - [1.12. Portability Problem](#112-portability-problem)
-  - [1.13. Distributing Testing Fixture](#113-distributing-testing-fixture)
-  - [1.14. Inheritance](#114-inheritance)
-  - [1.15. Object Creation](#115-object-creation)
-  - [1.16. No Polymorphism](#116-no-polymorphism)
-  - [1.17. Dependency Injection](#117-dependency-injection)
-
-## 1.1. Preface
+## Preface
 
 During this lesson, I want to conclude the object-oriented programming topic with a nontrivial example. I propose to learn more about object-oriented programming in the context of dependency injection design pattern. By pattern, I mean a programming archetype to solve a problem. It is a well-known and widely accepted pattern that is useful to be adopted in many scenarios. Those who have already heard about dependency injection may be concerned that this sounds like an introduction to an entirely different course but not a summary of this course. The concerns are justified, because many publications have already been written about dependency injection, and many frameworks exist on the market. There are also some terms used in this context like Inversion of Control, and Container we should be familiar with. The inversion of control we know from the previous lesson. To make the discussion transparent I will not use any framework. It allows for avoiding discussion about containers and reflection. Finally, you will learn the precise definition distinguishing object-oriented programming and dependency injection concepts. Let me stress that the main goal is not to be aware but to know how to use the dependency injection pattern. Especially I will pay attention to the differences between object-oriented programming and the dependency injection pattern. Again, this may sound puzzling, but I hope it will provide a basis for a better understanding of the object-oriented programming concept.
 
-## 1.2. What's the Problem?
+## What's the Problem?
 
-### 1.2.1. Main Topics
+### Main Topics
 
 - Testing Program
 - Dependence on Unknown Type
 
-### 1.2.2. Testing Program
+### Testing Program
 
 Before shipping to the production environment, the program should be tested. There are many testing methods that must be considered at the very beginning of commencing development. We also know that the layered architecture of the program could help to decouple parts and apply selectively the testing.  Previously we concluded that abstraction could be very useful. Now we can conclude that a variety of test requirements thanks to abstraction allows for providing a polymorphic solution. Abstraction requires object-oriented programming concept implementation.
 
-### 1.2.3. Dependence on Unknown Type
+### Dependence on Unknown Type
 
 Layered program architecture and testing using a dedicated testing environment, for example, unit tests cause a side effect. That is a direct reference to some definition of concrete types that becomes impossible because the type can be located in the layer above or in an independent testing project. Finally, we cannot use the new operator to create an instance in the place where it should be used. Again object-oriented programming helps to solve it. To distinguish this programming pattern we will use the dependency injection term.
 
-## 1.3. Library Example Description
+## Library Example Description
 
 Let's assume that our task is to ship a library for an unknown in advance number of users.  Additionally, we don't know where and how our library will be used. We can only assume that it will be a part of the logic layer. For the sake of simplicity, we are neglecting the existence of the data layer. It is not used and relevant in our example. The library examples to be investigated are located in the project DependencyInjectionLibrary. The first code snipped is called ConstructorInjection class. It contains several methods named Alfa, Bravo, Charlie, and Delta. Similar methods are gathered in the following example named PropertyInjection. In a production solution, we must provide only one implementation of the Alfa, Bravo, Charlie, and Delta methods using a constructor or property approach.
 
-## 1.4. Tasks
+## Tasks
 
 The first task you will face in a production environment is resolving a condition that makes the selection between the constructor and property injection pattern easier and more systematic.  Depending on the expected features both have some advantages and disadvantages that should help to make a decision. Here it is worth stressing that there is also possible to merge both and provide a hybrid solution but this scenario is out of our lesson scope and you may implement it on your own.
 
@@ -59,7 +35,7 @@ The second task is testing our program, and especially our library before shippi
 
 Testing the program text against the selected programming language syntax and semantics is a design-time activity, required to prove that we have a program. Fortunately, this work is usually done by the compiler so we may safely skip this task for now.
 
-## 1.5. Testing
+## Testing
 
 Testing the returned data and behavior correctness is a run-time task and requires the execution of the program in a testing environment. The testing environment must resemble the production environment to make useful results. It is hard at the design time because the production environment is not defined yet.  Usually, it is necessary to make the validity evaluation nondestructive. In other words, it should not disturb or even has an impact on the typical usage of the library in a production environment. Look at the library as a product.
 
@@ -67,50 +43,50 @@ This course is not focussed on testing therefore we can introduce many simplific
 
 In the ConstructorInjection and PropertyInjection classes, we have a few methods named Alfa, Bravo, Charlie, and Delta. For the sake of simplicity let's just assume that our job is to test only the sequence in which the methods are called. For testing purposes, I have applied a tracing mechanism. One of the benefits of this approach is the possibility to reuse it also in the production environment if needed. To test the sequence in which the methods are called each one calls an instance method of an object whose reference is assigned to the private `TraceSource` field. Because it is not about testing but about programming patterns the question, which will lead our discussion is how and where to create the object that is used for tracing purposes.
 
-## 1.6. Polymorphism
+## Polymorphism
 
 Consider two scenarios for testing this class. First, the classes could be used as a part of a hypothetical general-purpose library referred by in a console application. The second is unit testing. It is easy to guess that validation for these two examples must be implemented differently. So it is the first place where we must address polymorphism as a problem because the console application may use messages written on the screen to provide feedback and allow assessment of the implementation correctness by an application designer or user. For the unit testing, we must not use the user interface because it doesn't exist at all. Both test methods have been implemented and added to the design environment as independent projects called appropriately: DependencyInjectionUserInterface and DependencyInjectionTest. From this example, we can learn that our solution requires a polymorphic approach, I mean we need at least two independent implementations of the same functionality, namely tracing.
 
-## 1.7. Polymorphism Implementation
+## Polymorphism Implementation
 
 We may implement polymorphic solutions using abstraction, inheritance, and implementation. As I said previously, there are two examples but the first one I will use is the ConstructorInjection class. I used abstraction to define the type of the `TraceSource` field of the class. Its value is assigned while the class constructor is executed. In this language, we call it field of class but in general, it is just a variable, I mean value holder. The type of this variable is `ITraceSource`. Using F12 we can get the type definition. It is an interface that defines just one method called `TraceData`. The interface is an abstract definition. The interface construct is an abstract definition because it doesn't provide any implementation details and can be recognized as a contract between the class `ConstructorInjection` and any user of this class, that is any creator of this class. We know that the object referred to by this variable has the TraceData method implemented, and the signature of this method is defined by the mentioned interface. Finally, we are calling a method but we are not aware of its implementation details. At run time when we are talking about objects, all implementations must be defined in the place the object is created, but the implementations can be different depending on the needs of a creator. According to this contract, there are two clear roles. First is the interface user. In this case, it is the `ConstructorInjection` class. The second is the implementation provider, and in this case, it is a console application or a unit test. In this place, we are using the reference of abstract type but we know that to create any object a concrete class must be derived from this interface.
 
-## 1.8. Calling Abstract Method
+## Calling Abstract Method
 
 Here we can see that the `TraceSource` field contains a reference to an object, but its type has been declared as an interface offering one method. Here, however, based on the interface definition we indicate that the object must provide an implementation of the `TraceData` method, but again we should not assume how this operation works. As I said it is just a kind of contract. We only specify a formal declaration containing a formal list of arguments because we define only the header of the method called the method signature. As a result, the declaration is there, but it hides (or it rather doesn't provide) implementation details and that is why we call it an abstract declaration. This does not prevent you from using it and calling it, passing to it the current values ​​of its arguments in accordance with the declared signature.
 
-## 1.9. Command Line Application
+## Command Line Application
 
 I'll come back to unit tests shortly, but now let's examine an example of tracing process implementation to be used by the console application. The result on the screen we can observe by running the console application. As you can see, the result is four messages displayed on the screen, which can then be used to determine the sequence of method calls and to diagnose manually the correctness of this sequence. This behavior is provided by a custom implementation of the interface. The object of this class is created and assigned to the constructor of the ConstructorInjection class. The question is if this solution is entirely based on an object-oriented programming paradigm. Let's analyze in detail all the code parts in concern. Here we have abstraction. To the parameter of the abstract type, we are assigning a reference to the object created using the class derived from the interface using inheritance. Concluding, everything looks compliant with the object-oriented programming concept. There is nothing special, nothing extraordinary compared with the object-oriented programming concept.
 
-## 1.10. User Interface Problems
+## User Interface Problems
 
 In this solution where the user interface is used for diagnostic purposes, we can indicate several important problems related to this implementation. In a production environment, such displaying of diagnostic information on the screen for the user may be confusing and useless because the end user doesn't know the correct sequence, doesn't know the meaning of these messages, or doesn't care about the diagnostic information - the program should be correct and that's it. Today, for the production environment, we usually use a graphical user interface. In this case, displaying several diagnostic lines of messages is not a good idea in general. Let's add that unit tests do not have UI support, so displaying anything to the user is useless. Summing up, we can see that the discussed solution is not practical for the production environment, although on-screen diagnostics has always been a favorite approach for novice programmers, because only lack of experience explains the thoughtless omission of the issue in which there are, for example, several thousand lines. Anyway, the example should be recognized only as another implementation of the testing stuff. It doesn't decrease applicability comparing it with a unit test and our discussion about polymorphism.
 
-## 1.11. Implementation in Library
+## Implementation in Library
 
 Let's return to the polymorphic problem we have. Just to recall, we need two independent implementations of the `ITraceSource` interface. One is for the command line application. The second is for unit testing purposes. Of course, we can implement all variants inside the library that will provide the appropriate functionality for each of the cases mentioned. To avoid using our imagination let me try to expand this example and implement the interface locally. I am creating MyClass which inherits the `ITraceSource` interface. Using the context menu we may implement this interface to create a concrete class that the ConstructorInjection class can use. In this case, the object used for the diagnostic purpose can be instantiated locally, and passing by the argument the trace engine may be omitted. To support variants the type of argument may be replaced by enumerations allowing for a selection of a variant predictable at design time. For sake of simplicity, this case is omitted. The code is kept as simple as possible. Of course in this case the defined class doesn't implement any actual functionality - it just throws the not implemented exception. I will try to prove shortly that it is a very bad solution.
 
-## 1.12. Portability Problem
+## Portability Problem
 
 This approach - I mean local implementation of the diagnostic functionality - is only possible if we could predict all behavior variants we will need in the future. The future time - that I have used in the previous sentence - suggests that it is impossible or at least impractical because I immediately think of a few other ideas on how such diagnostics can be implemented in a different way, for example saving diagnostic messages to a file, or maybe logging the diagnostic information to the cloud, and there is also a database that may be considered. Let's add that the implementation of the logging mechanism on the screen inside the library will result in the necessity to answer the next question: what technology to use, for example, console application as in the example, Windows Presentation Foundation, or Forms in case of Windows operating system. But in general, local implementation of selected scenarios at design time is devastating for portability ar run time because it requires that the technology exists on the target execution platform.
 
-## 1.13. Distributing Testing Fixture
+## Distributing Testing Fixture
 
 It is beyond the course scope but it is worth stressing now that the diagnostic information may be generated at run time for testing or maintenance purposes. If the main goal to create the diagnostic information is testing everything that is not necessary should be removed from the library to avoid shipping a code that is partially useless for the production environment. For example, the implementation of the interface `ITraceSource` that if defined in the code should be located outside of the library assembly to minimize its memory footprint and execution time. Before considering the local implementation of diagnostic information logging, first, we must answer the question of if this functionality is required in the production environment. Again, if the main purpose is to engage this functionality as the testing fixture we must avoid implementing it as part of the library to avoid shipping useless functionality to the end user. In this case, the local implementation should do nothing as in the example. Now we can use this class as the default implementation instead of throwing the argument null exception if the input attribute is null.
 
-## 1.14. Inheritance
+## Inheritance
 
 During the program execution phase, the expected algorithm must be implemented. This can only be ensured by creating objects from concrete types, so only objects with all implementation details can be instantiated. In the considered example for this interface, it is necessary to declare a new type that will provide this interface implementation. Using the navigation let's look for all references. On the list we get, we have a few suggestions, but let's choose the one that relates to the project of the previously launched sample console application. Here we see this relationship where the new type is defined with the use of the source type. We call this relationship inheritance, the source type is called the base type, and the newly created type we call the derived type. There are other terms, but I will use these consequently. In the newly created concrete class, all abstract declarations must be refined in such a way that the missing implementation details are provided. In our case, the block is missing in the TraceData method, which we add here to the signature of the method inherited from the interface. We call this process the abstraction implementation. As a side note, a block is a sequence of instructions separated by a semicolon - sometimes it is also called body for some reason.
 
-## 1.15. Object Creation
+## Object Creation
 
 In order for our example to be finished, it is still necessary to specify what specific object implemented the tracing functionality is to be used in the library. Previously, I used a very broad statement, namely: some object whose reference is assigned to a field. So now is a good time to clarify this statement. This field is initialized in the class constructor using the current value of this argument. The instantiation of an object of this class can be found again by using the navigation available in the context menu and looking for all references to this constructor. An object of this class is instantiated in the sample program and a reference to it is passed to the constructor of the library class from which the methods of its instance are called in the sequence. In this case, the reference to the created object becomes the current argument of the constructor.
 
-## 1.16. No Polymorphism
+## No Polymorphism
 
 In this example, we started with a polymorphism requirement that was shown as a problem to solve, and then we applied the object-oriented programming paradigm including abstraction, inheritance, and implementation to solve it. Well, as a result, use your imagination and consider the case where we have the console application only for testing purposes. In this case we don't have polymorphism at all. In this particular case, there is no diversity, the program always behaves the same. What's more, there is even no need to use a variant solution, because its behavior is not even parameterized. Is the use of the entire object-oriented programming engine redundant then?
 
-## 1.17. Dependency Injection
+## Dependency Injection
 
 Of course, answering this question we say no it is not a redundant approach because we must take into account the fact that the driving force behind our approach and the problem to be solved was the need to take into account polymorphism in future solutions, and not only in a specific solution, I meant in the library itself. The word "future" is the most important because it means that where the object is referenced, its type is unknown because its definition will be compiled later. And it doesn't matter if it's a few milliseconds later or years later. I named this pattern described here dependency injection to somehow terminologically distinguish the situations of using object-oriented programming to implement a potential polymorphism and using it to create variant local solutions. Concluding, in this scenario, we deal with the separation of concerns. One is the usage, and the second is implementation. Hence, shortly the dependency injection is a pattern where we are using unknown for some reason type that we replace by abstraction. Here the type is located in an independent assembly so cannot be referenced directly to avoid circular references between assemblies. Later, while discussing layered program architecture, we will learn the next example where direct access to the concrete type is impossible and must be replaced by abstraction. Shortly, the dependency injection is a pattern we must apply in any scenario where we cannot use the new operator in the place of use to create an object because the type is or shall be unknown for some reason.

--- a/InformationComputation/GenericClassesMethods/README.md
+++ b/InformationComputation/GenericClassesMethods/README.md
@@ -1,67 +1,36 @@
-# 1. Generic Types and Methods
+# Generic Types and Methods
 
-## Table of content  <!-- omit in toc -->
-
-- [1. Generic Types and Methods](#1-generic-types-and-methods)
-  - [1.1. Preface](#11-preface)
-  - [1.2. What is the Problem?](#12-what-is-the-problem)
-  - [1.3. Introduction](#13-introduction)
-    - [1.3.1. Type Reusability](#131-type-reusability)
-    - [1.3.2. Inheritance](#132-inheritance)
-    - [1.3.3. Template](#133-template)
-    - [1.3.4. Conclusion](#134-conclusion)
-  - [1.4. Overview](#14-overview)
-    - [1.4.1. Introduction to Example](#141-introduction-to-example)
-      - [1.4.1.1. Sequence of Values](#1411-sequence-of-values)
-      - [1.4.1.2. Compatible Values](#1412-compatible-values)
-    - [1.4.2. Introduction (Node)](#142-introduction-node)
-    - [1.4.3. Wrapped Value (Node)](#143-wrapped-value-node)
-    - [1.4.4. Wrapped Value Type (Node)](#144-wrapped-value-type-node)
-    - [1.4.5. Using Object Type (Node)](#145-using-object-type-node)
-    - [1.4.6. Introduction of Generic Type (`Node<TypeParameter>`)](#146-introduction-of-generic-type-nodetypeparameter)
-    - [1.4.7. Declaring Type Using Generic Definition (IntSequenceTest)](#147-declaring-type-using-generic-definition-intsequencetest)
-    - [1.4.8. Using Generic Type (AnyClassSequenceTest)](#148-using-generic-type-anyclasssequencetest)
-  - [1.5. SelfDictionary (SelfDictionary)](#15-selfdictionary-selfdictionary)
-  - [1.6. SelfDictionary Unit Test introduction (SelfDictionaryTest)](#16-selfdictionary-unit-test-introduction-selfdictionarytest)
-  - [1.7. Adding Equatable to improve indexer (SelfDictionaryTest)](#17-adding-equatable-to-improve-indexer-selfdictionarytest)
-  - [1.8. Main Goal of Unit Test (SelfDictionaryTest)](#18-main-goal-of-unit-test-selfdictionarytest)
-  - [1.9. Where Construct Introduction (SelfDictionaryTest)](#19-where-construct-introduction-selfdictionarytest)
-  - [1.10. Constraints on Type Parameters](#110-constraints-on-type-parameters)
-  - [1.11. Generic Methods](#111-generic-methods)
-  - [1.12. Constraints on Type Parameters Syntax](#112-constraints-on-type-parameters-syntax)
-  - [1.13. See also](#113-see-also)
-
-## 1.1. Preface
+## Preface
 
 In this lesson, we focus on generic types and methods. They are especially important because they expand object-oriented programming somehow and consequently extend our possibilities of reusing the previous results and this, as we know, decreases the total costs of software development. As usual, let's start by defining the problem.
 
-## 1.2. What is the Problem?
+## What is the Problem?
 
-## 1.3. Introduction
+## Introduction
 
 - Type reusability
   - inheritance
   - template
 
-### 1.3.1. Type Reusability
+### Type Reusability
 
 We know that the possibility of reusing the results of previous programming work is extremely important. It improves economic efficiency but additionally it is beneficial for reliability and minimizes training costs. From the previous lessons, we also know that the type concept is extremely important for modern programming languages. Therefore, simplifying, we could define the problem as the reusability of the already defined types.
 
-### 1.3.2. Inheritance
+### Inheritance
 
 Inheritance paradigm, that is, the ability to reuse a predefined type called a base type to create a derived type is the main reason for the wide leveraging of object-oriented programming concept, which was introduced as one of the pillars of this concept. In previous lessons, we learned that a type is a collection of values and operations on those values. Simply put, in the case of inheritance, a derived type takes over the characteristics of the base type and allows you to add new and modify the existing functionality. You can also extend the set of values, that is, the set of values of the derived type contains a set of values of the base type.
 
-### 1.3.3. Template
+### Template
 
 Using parametrized templates is an alternative to inheritance with the purpose to improve reusability. I remember a similar concept was applied to define subprograms ages ago. Procedures, functions, and methods known in modern programming languages may also be classified as templates with formal parameters. Unfortunately, all of that must also be classified as at least partially run-time solutions because the actual values of the arguments are determined while executing the program. Entirely design time solutions like inheritance allowing definition of parametrized templates is a macro concept. This concept also comes from the very beginning of the software engineering era. I am not expecting that you remember the subprogram or macro concepts because this lesson is not about the history of software engineering. It must be also stressed that mentioned terms describe very broad ideas. Anyway using templates to improve reusability is not something new. The main goal of this lesson is to prove that we can create programmable patterns with formal parameters. The actual values of these parameters may have an impact on the template behavior at run-time or the final definition created from a template at design time. During this lesson, we will investigate how this last option could be applied to create type templates. We will call these templates generic types. The generic word stresses the reusability of a template to define types.
 
-### 1.3.4. Conclusion
+### Conclusion
 
 Before deep diving into generic types let me stress that it is a lexical construct. It means that before using it to create a concrete type definition all parameters must be resolved. To resolve in this context means that they must be replaced by actual ones at design time.
 
-## 1.4. Overview
+## Overview
 
-### 1.4.1. Introduction to Example
+### Introduction to Example
 
 As a foundation to investigate the generic types I propose to consider a scenario in which we want to represent a sequence of values, a sequence of compatible values. The sequence is made up of many values and all the values must be of compatible types. The main reason is that we are going to reuse the sequence management functionality in spite of the type of collected values provided that all values collected are compliant with each other in this sequence. But before that, two questions must be addressed. The first question is:
 
@@ -71,74 +40,74 @@ and the second question:
 
 - compatible values - what it is?
 
-#### 1.4.1.1. Sequence of Values
+#### Sequence of Values
 
 Addressing the first question we can explain, that in general, the sequence is an ordered collection of entities in which each member knows the next one. In such a relationship, the last and the first must be distinguished because the first element is not pointed out by any item belonging to the collection, and the last element, in turn, does not point to any subsequent item. Let's try implementing this structure - I mean items relationship - in the program code.
 
-#### 1.4.1.2. Compatible Values
+#### Compatible Values
 
 To answer the second question let me recall that CSharp is a strongly typed language. Every variable and constant has a type. The same applies to formal arguments of methods and the returned value if any. It is also worth stressing that every expression evaluates to a value of a well-defined type at compile time. The main reason for that is that the compiler uses type definition to ensure all operations performed in your code are type-safe. It protects against assigning to variable value that doesn't belong to a set of allowed values predefined by its type. When you declare a variable or constant in a program, you must specify its type or use the var keyword to let the compiler infer the type.  After you declare a variable, you can't redeclare it with a new type, and you can't assign a value not compatible with its declared type.  Concluding, after the creation of a sequence of values all nodes in the sequence must be a wrapper of a value compatible with the selected type. Additionally, it should be possible to select the type randomly.
 
-### 1.4.2. Introduction (Node)
+### Introduction (Node)
 
 Let the representation of a values sequence - that we are talking about - be created using the class `Node`. In this class, the first thing we need to implement is a pointer to the next item in the built-up sequence. I propose to add a reference to the next item as the `Next` property.  The next thing we need to do here is an implementation of common sequence management operations, for example adding new items to the sequence. Let's assume that we add new nodes at the beginning of the sequence and let's do it by engaging the class constructor for this task, which will ensure that the newly created element will be inserted at the beginning of the sequence.
 
-### 1.4.3. Wrapped Value (Node)
+### Wrapped Value (Node)
 
 The last question we have to address is how to represent the values ​​in the sequence. Every instance of the class `Node` in the sequence has to represent a value that is compatible with a selected type. In other words, all values collected by the series using the `Node` class instances must be compatible with each other. By answering this question, we can add a property to the previously defined class representing one item in the sequence that is responsible for the representation of a single value added to the sequence. As the result, the value holder item, namely an instance of the `Node` class plays the role of a wrapper of a single value in the sequence. And here the next question must be raised, what type is this value to be?
 
-### 1.4.4. Wrapped Value Type (Node)
+### Wrapped Value Type (Node)
 
 The last question we have to address is how to represent the values ​​in the sequence. Every instance of the class `Node` in the sequence has to represent a value that is compatible with a selected type. In other words, all values collected by the series using the `Node` class instances must be compatible with each other. By answering this question, we can add a property to the previously defined class representing one item in the sequence that is responsible for the representation of a single value added to the sequence. As the result, the value holder item, namely an instance of the `Node` class plays the role of a wrapper of a single value in the sequence. And here the first question arises, what type is this value to be?
 
-### 1.4.5. Using Object Type (Node)
+### Using Object Type (Node)
 
 In case the type is hardcoded if we wanted to change the decision regarding the type or use this functionality again but for another, not compatible type this approach leads to rewriting or cloning this functionality, although it is so universal that we could basically use it to represent values ​​of any type. Rewriting means that we cannot add it to a sharable library. Of course, this obstacle we may overcome by taking advantage of the fact that all types inherit from the `object` type and all are therefore compatible with that type. So this way, we can ensure that the same type, I mean `object`, will be used for any other type while creating a new Node instance. It is not true while reading the saved value from the selected node. Of course, then we do not have the option to choose the type really, because all types are compatible with the type object while assigning a new value to the variable of the type `object`. So, again, the assumption that the types should be compatible is not met, because in this case, we are only applying a workaround that works while adding new values to the sequence but not a generic solution. In other words, this approach makes the solution weakly typed, and finally, it postpones type checking up to the run time. Therefore, we must look for another approach that will allow us to ensure that the type definition is generic in terms of the possibility of using different types on the one hand, and support the possibility to check the compatibility of types at design time on the other hand Sometimes this requirement may be called a type-safe approach.
 
-### 1.4.6. Introduction of Generic Type (`Node<TypeParameter>`)
+### Introduction of Generic Type (`Node<TypeParameter>`)
 
 We can achieve it by using a type template with parameters - as here in this example - instead of the definition of a concrete type, the template has a parameter. We may use the template to define new concrete types provided that the formal parameters of the template are replaced by names of concrete types. Again, the idea is to use a parameterized template of a type definition instead of the concrete type definition itself. At this point, angle brackets surround a list of parameter names separated by commas. It is worth stressing now that it is a lexical approach called generic type. Because by design all formal parameters defined between the angle brackets represent a type they can be used in all places where the type identifiers are expected according to the language rules. For example, in the case of a property, we always return a value ​​that is compatible with this type.
 
-### 1.4.7. Declaring Type Using Generic Definition (IntSequenceTest)
+### Declaring Type Using Generic Definition (IntSequenceTest)
 
 Let's repeat the question. If we haven't defined the type but only some type template, or a blueprint, then when does the type definition come into existence? To investigate it, I created the test class `NodeUnitTest` in which we will use a test method to create an instance of this generic type. We cannot use generic classes to instantiate them without defining a list of actual types. To reuse this template of a class and declare a new type we must replace the formal parameter of this generic type with an identifier of the existing type. In this case, it is int. The definition using the int type is created by the compiler for us and as a result, we can create the first node of the sequence and assign the reference to the created instance to the variable `firstNode`.  This variable is prefixed with the same type. The variable points to the first node in the sequence. The constructor requires two actual arguments. The arguments of the constructor play the same role as in the classic definition of a type. The first argument provides the reference to the next node in the sequence. In this example, we don't have yet created anyone. The created node is the first and the last one at the same time.  The second actual argument of the constructor is used to assign a value that is to be protected by the sequence.  The type of this argument is determined by the parameter of the generic type.  The actual parameter value and the formal parameter type must be compatible with each another at compile time.
 
-### 1.4.8. Using Generic Type (AnyClassSequenceTest)
+### Using Generic Type (AnyClassSequenceTest)
 
 For the sake of this example, I will try to declare a new type using the previous generic template here. In this example, the `AnyClass` represents a custom type of values to be managed using this sequence. On the left-hand of this statement, we have a variable that is to reference the first node as previously. This variable is prefixed by a generic type with the actual parameter called  `AnyClass`. On the right-hand of the assignment operator, we are trying to instantiate that type to assign the new instance reference to the variable being declared. We can see that we have some issues. The first is due to the fact that the actual parameter of the generic type is unknown. As I said we must use an identifier that identifies existing concrete type declaration. Therefore, let's create such a class locally below in the same file. This way we can ensure that a type definition is implicitly generated by the compiler from the template and this template is generic because we can use the same functionality for different types replacing the type parameters randomly. In other words, the template parameter is only a placeholder for a specific type. To apply this template to create a type definition it has to be replaced with an identifier of any known type. The next two line shows how to add the next node to the sequence and how to check that each node points to a different value.
 
-## 1.5. SelfDictionary (SelfDictionary)
+## SelfDictionary (SelfDictionary)
 
 To improve our understanding of the generic type concept let's dive into the details of a slightly more advanced type definition example. In the previously considered scenario, elements are added to a set engaging the dependencies between them based on a sequence. Therefore, it had the disadvantage that the items were not randomly available. I mean there is no indexer allowing to select freely elements in the set using a unique key. We need to use browsing to implement sequential access. Now let's try to consider another scenario in which the nodes are arranged in such a way that they are randomly selectable. Again, in this context, randomly does' t mean accidentally just freely. In other words, the next item may be selected regardless of which one was selected previously. It means that this time addressing should be used instead of browsing. To do this, I define a new type and use the `Dictionary` type as the base type, so it uses inheritance here. The Dictionary type is already defined in the existing .NET library and has two type parameters. So it is a generic type. The first parameter specifies the type that is used as a key to select individual components. So it acts as an index on a one-dimensional array. The second type determines what values will be stored in this array. Consider a case in which the value itself, i.e. the one we want to store, can also be used as the index. Therefore, there is only one parameter in the newly created generic type. Let's also add a method that adds a new value to the array. At the same time, this operation uses the same value as the index; as the value selector. Let's analyze how the implementation of this scenario will behave using a unit test.
 
-## 1.6. SelfDictionary Unit Test introduction (SelfDictionaryTest)
+## SelfDictionary Unit Test introduction (SelfDictionaryTest)
 
 For this purpose, let's create a unit test in which we will check the features of the proposed solution. In the window below I added a test method in which we instantiate a new dictionary according to the previously defined type and add two elements to this dictionary. We can check that as a result of this operation there are indeed two elements in the dictionary and we have free access to these elements. The question is how to control, how to select the individual items that are in the dictionary. In this case, it is completely dependent on the implementation of the Dictionary class that the environment provides. It is independent of our needs. The following example shows how to control this process. In other words, how to make sure that a proper item is selected from the dictionary.
 
-## 1.7. Adding Equatable to improve indexer (SelfDictionaryTest)
+## Adding Equatable to improve indexer (SelfDictionaryTest)
 
 A situation in which we have no control over the behavior of the newly created type is not promising and should not be acceptable to us because operation correctness is always our responsibility. If we don't have control the correctness could be questioned. Therefore, let's try to take advantage of the fact that the `Dictionary` - that we used as the base type to derive the new type - may use the `IEquatable` interface if it is implemented by the type of the key to comparing, and therefore also to perform a selection of a value from the dictionary. The implementation of this interface will allow us to restore full control over how elements in the dictionary are organized and how to select individual elements. As this method is not implemented at the moment, the unit test will fail. The test has finished and we can see that the result is actually negative because this method is not implemented and an exception occurs in it. Therefore, let us indicate in the test that we expect such an exception, and thanks to this, the next test result is marked as a success, and therefore we will be sure that the `Equals` method is actually used, it is called. This method is also used to organize elements in the dictionary.
 
-## 1.8. Main Goal of Unit Test (SelfDictionaryTest)
+## Main Goal of Unit Test (SelfDictionaryTest)
 
 Now I must stress that the main intent of the presented unit tests is an explanation but not a validation of algorithm implementation. Its role is just to show that the tested code has certain features.
 
-## 1.9. Where Construct Introduction (SelfDictionaryTest)
+## Where Construct Introduction (SelfDictionaryTest)
 
 Since in the solution, we used particular capabilities of the type that is the parameter for the generic type, a question arises as to how to force situations so that all types used as the actual generic type parameter have this capability. The `where` construct comes in handy here, which allows us to state that the actual parameter that substitutes a formal parameter for the type must inherit from the `IEquatable` interface. As a result, when our type does not meet this requirement, let's remove the inheritance from a specific type. We see that immediately there is a compilation error, which indicates that the required capabilities for the selected type are not present, i.e. our newly created type used as the current parameter does not meet the expectation of the designer, it does not have the capabilities that are required in the definition of the generic type. Accordingly, the `where` clause in this application can be considered as a solution that allows specifying the required capabilities of the type parameters, which can be utilized inside the template. On the other hand, the `where` clause restricts the applicability of existing types if the type doesn't have the required capabilities, so it is also often considered a constraint of actual types.
 
-## 1.10. Constraints on Type Parameters
+## Constraints on Type Parameters
 
 - constraints on type parameters c# example
 - [Generic classes and methods](https://docs.microsoft.com/dotnet/csharp/programming-guide/generics)
 
 The language-defined constraints that we can use are described in detail in the manual available on MSDN. Ask Google "constraints on type parameters c# example" to get a link to the documentation. The URL to this manual can be found in the support material and is visible on the screen. Below I have added a table summing the where construct semantics. Again, check out the language documentation to get more.
 
-## 1.11. Generic Methods
+## Generic Methods
 
 Finally, let's mention the generic methods. The syntax and semantics of generic method definitions are very similar to the syntax and semantics of the type definition. An example is the Assert class extensively used in the unit test examples. We also have here, as in the case of types, a list of formal type parameters, which we can then use in each place where we use the type identifier. Again, this parameter is a formal parameter and must be replaced in the calling operations by an identifier of an existing type. We also have a `where` construct, which allows us to specify what type can be the actual parameter.
 
-## 1.12. Constraints on Type Parameters Syntax
+## Constraints on Type Parameters Syntax
 
 Constraints are specified by using the `where` contextual keyword. The following table lists the seven types of constraints:
 
@@ -154,7 +123,7 @@ Constraints are specified by using the `where` contextual keyword. The following
 
 Some of the constraints are mutually exclusive. All value types must have an accessible parameterless constructor. The `struct` constraint implies the new() constraint and the new() constraint cannot be combined with the `struct` constraint. The unmanaged constraint implies the `struct` constraint. The unmanaged constraint cannot be combined with either the `struct` or new() constraints.
 
-## 1.13. See also
+## See also
 
 - [Generic classes and methods](https://docs.microsoft.com/dotnet/csharp/programming-guide/generics)
 - [Constraints on type parameters](https://docs.microsoft.com/dotnet/csharp/programming-guide/generics/constraints-on-type-parameters)

--- a/InformationComputation/LayeredArchitecture/README.md
+++ b/InformationComputation/LayeredArchitecture/README.md
@@ -1,99 +1,55 @@
-# 1. Program Layered Architecture
+# Program Layered Architecture
 
-## Table of content <!-- omit in toc -->
-
-- [1. Program Layered Architecture](#1-program-layered-architecture)
-  - [1.1. Preface](#11-preface)
-  - [1.2. What is the problem ?](#12-what-is-the-problem-)
-  - [1.3. Life Cycle of Program Development](#13-life-cycle-of-program-development)
-    - [1.3.1. Information Processing](#131-information-processing)
-    - [1.3.2. Algorithm](#132-algorithm)
-    - [1.3.3. Program](#133-program)
-    - [1.3.4. Separation of Concerns is Required](#134-separation-of-concerns-is-required)
-    - [1.3.5. Program Testing](#135-program-testing)
-    - [1.3.6. Maintenance](#136-maintenance)
-  - [1.4. Layered Architecture](#14-layered-architecture)
-    - [1.4.1. Introduction](#141-introduction)
-    - [1.4.2. Layers relationship](#142-layers-relationship)
-  - [1.5. Layered Architecture Benefits](#15-layered-architecture-benefits)
-    - [1.5.1. Introduction](#151-introduction)
-    - [1.5.2. Simultaneous development](#152-simultaneous-development)
-    - [1.5.3. Independent Testing](#153-independent-testing)
-    - [1.5.4. Technology Change Adaption](#154-technology-change-adaption)
-    - [1.5.5. Scalability Leveraging](#155-scalability-leveraging)
-  - [1.6. Layers](#16-layers)
-    - [1.6.1. Introduction](#161-introduction)
-    - [1.6.2. Responsibility](#162-responsibility)
-    - [1.6.3. Presentation Layer](#163-presentation-layer)
-    - [1.6.4. Logic Layer](#164-logic-layer)
-    - [1.6.5. Data Layer](#165-data-layer)
-  - [1.7. Layers Dependency Rules](#17-layers-dependency-rules)
-    - [1.7.1. Presentation to Logic](#171-presentation-to-logic)
-    - [1.7.2. Presentation to data](#172-presentation-to-data)
-  - [1.8. Deployment Layers](#18-deployment-layers)
-    - [1.8.1. Layered Architecture of Program Text](#181-layered-architecture-of-program-text)
-    - [1.8.2. Layered Architecture in Program Context](#182-layered-architecture-in-program-context)
-    - [1.8.3. CSharp as Language](#183-csharp-as-language)
-    - [1.8.4. Layer as Group of Custom Type Definitions](#184-layer-as-group-of-custom-type-definitions)
-    - [1.8.5. Namespace as Set Boundary](#185-namespace-as-set-boundary)
-    - [1.8.6. Relationship Implementation](#186-relationship-implementation)
-    - [1.8.7. Selection of Layer Membership](#187-selection-of-layer-membership)
-    - [1.8.8. Abstract Layer Interface](#188-abstract-layer-interface)
-    - [1.8.9. Applying Object-oriented Programming](#189-applying-object-oriented-programming)
-    - [1.8.10. Inheritance and polymorphism](#1810-inheritance-and-polymorphism)
-    - [1.8.11. Implementation for testing purpose](#1811-implementation-for-testing-purpose)
-  - [1.9. That's all for now](#19-thats-all-for-now)
-
-## 1.1. Preface
+## Preface
 
 I would like to invite you to participate in the next lesson of the course Information Computation. The main goal of this lesson is to learn more about the architecture of the computer program. A computer program begins its life cycle as a text that follows the rules of a selected programming language, for example, CSharp. In order to decrease the cost and improve the performance of the program development process, often the text of the program is organized into autonomous fragments hierarchically related to each other creating a layered model. The main challenge we must face during this lesson is learning all about computer program layered architecture.
 
-## 1.2. What is the problem ?
+## What is the problem ?
 
 - what benefit we should expect
 - how this architecture should be implemented
 
 It's just theory but from the practical point of view, we need to answer a few questions to follow up and apply this architecture. First is what benefit we should expect compared with the program that is just messy. We are expecting measurable benefits. It could be even better if we can prove that this architecture is mandatory for some reasons. The second question is how this architecture should be implemented to be rewarded by finally receiving the expected benefits.
 
-## 1.3. Life Cycle of Program Development
+## Life Cycle of Program Development
 
-### 1.3.1. Information Processing
+### Information Processing
 
 To deploy the automation of information processing - let me remind you that it is the main goal of the software developer job - we have to engage a computer. That is a programable device. To be helpful in solving our problem the computer needs to execute a program. Computation is the process of running a program. It is a run-time stage of the program development process. A computer program is a piece of software that is designed, developed, deployed, and maintained by us as a community or even team job responsibility.
 
-### 1.3.2. Algorithm
+### Algorithm
 
 The program development should be commenced by researching knowledge helpful to solve our problem or achieve the computation goal. This knowledge as one whole we call algorithm. A very useful concept while working on the algorithm is a separation of concerns. From sociology we know, that it improves our performance of thinking because thanks to the separation of concerns we may think about independent topics with minimal overlapping between them. So to improve our productivity at algorithm design time we must leverage separation. It is important because by improving productivity we are decreasing development costs and decreasing probability of the failure in the long run. Finały as a result we are reducing development costs.
 
-### 1.3.3. Program
+### Program
 
 Unfortunately, usually designing an algorithm and its implementation are tightly coupled with each other and cannot be disjointed. It could even happen that after finishing the work on the program text the next step is to document the algorithm implemented by the program. It is not hard to imagine iteration in this respect. Anyway, at the end of the day, we must have a program executed by a computer for information processing automation purposes. Simplifying we can recognize the program as a text compliant with selected programming language syntax and semantic rules. Additionally, before it may be used by a computer it must be converted to a binary executable form because each computer is a binary machine. Usually, this transformation and validation are accomplished thanks to a compiler that is responsible to build the outcome of our work and is aware of the programming language in concern. It is worth stressing that only errors free text could be recognized as a computer program. If the compiler complains about the correctness of text it is just a sequence of characters but not a program worth further analysis against its meaning, against semantic rules.
 
-### 1.3.4. Separation of Concerns is Required
+### Separation of Concerns is Required
 
 Unfortunately, this introduction doesn't explicitly answer the question of when and where we should deal with the separation of concerns - while thinking about the solution or while implementing it as a text. The only thing that is out of the discussion is that it is very beneficial to apply separation of concerns. What's more, shortly I will try to prove that it is also necessary for some reasons. To prove that something is required,  or even necessary - we need a condition that may be easily verified. A typical condition in this respect should sound like this: without implementation of the separation of concerns concept, it will be impossible to ......\<to do something\>. Anyway, talking about the program we are talking about the text. Taking about the text it is impossible to talk about the concerns as long as the text doesn't have meaning but we can distinguish program parts according to selected language constructs. It looks like the only way to implement the separation of concerns concept. Continuing we may call this implementation a separation of parts. Further, we try to find constructs that are applicable in almost all programming languages that can be used to define separate parts implementing the separation of concerns concept.
 
-### 1.3.5. Program Testing
+### Program Testing
 
 Separation of parts is necessary to effectively apply unit testing to verify the correctness of the outcome. Unit testing is a testing method by which individual parts of source code are tested to determine whether they are fit for use. From this description, we can learn that distinguishing program parts are necessary to engage this kind of program validation method.
 
-### 1.3.6. Maintenance
+### Maintenance
 
 For maintenance purposes, independent parts also may be recognized as beneficial because any required modification could be scoped only to selected parts. It limits the impact on the correctness and performance of the program. Again this way we can improve our software development performance.
 
-## 1.4. Layered Architecture
+## Layered Architecture
 
-### 1.4.1. Introduction
+### Introduction
 
 Concluding, implementing the separation of concerns concept in practice we must deal with a program, but not only with the design thinking. A computer program begins its life cycle as a text that follows the rules of a selected programming language, for example, CSharp. In order to improve the performance of the program development process as a result of applying the separation of concerns concept, often the text of the program is organized into autonomous fragments hierarchically related to each other creating a layered archetype. In this architecture, each layer refers only to the layer below. Of course, there is no reference to the top layer at all. Similarly, the bottom layer doesn't refer to any other layer because there is no layer below. The layered program design pattern is clear and doesn't need any special education background or explanation to understand it but it is only an example. Hence, my proposal is to use it for further discussion but keeping in mind that it is only an example how to deploy the separation of concerns in practice.
 
-### 1.4.2. Layers relationship
+### Layers relationship
 
 To have layers we must be able to distinguish the vertical hierarchy, and position of the layer in a stack. For example, the top, middle, and bottom layers. Doesn't matter what the layer means. It could be books, carpets, or autonomous program parts. Hence, in the layered arrangement, the most important thing is the unidirectional top-down relationship. In a layered architecture, layer relationships could be recognized as a directed association. The directed associations are a relationship between entities that are navigable in only one direction, from top to bottom. Transferring this concept to the program a directed association indicates that the upper layer depends on the layer directly below it. A most common form of a directed association is a solid line with an arrow that indicates the direction of navigation and the top-down relationship. For the picture on the paper or on screen, it is obvious but for the program text, it could not be so clear.
 
-## 1.5. Layered Architecture Benefits
+## Layered Architecture Benefits
 
-### 1.5.1. Introduction
+### Introduction
 
 By applying the layered architecture we should gain measurable benefits compared with the program that is just messy. It could be even better if we can prove that this architecture is mandatory for some reasons. Let's try to justify the following benefits to name only the most important:
 
@@ -102,27 +58,27 @@ By applying the layered architecture we should gain measurable benefits compared
 - the adoption of technology change - to improve adaptability
 - scalability - it is easier to spread the functionality to different computers
 
-### 1.5.2. Simultaneous development
+### Simultaneous development
 
 Because the implementation of the layers is independent we may consider simultaneous development of them to reduce design time and make the development process chipper. Simultaneous layers development, following the more general concept called Simultaneous Product Development (SPD), is a design collaboration method in which team members work in parallel, synchronously, or asynchronously, to create and finalize the product. Simultaneous means occurring, operating, or done at the same time. Finally, we can reduce the time to market by reducing the time needed for development.
 
-### 1.5.3. Independent Testing
+### Independent Testing
 
 There is one more good reason for leveraging layered architecture. Before shipping our implementation to the post-production processing you must assure the correctness of the proposed solution somehow. Sometimes as proof of correctness we can get a statement like "it just works". Unfortunately, in many cases, it is just wishful thinking. However often it means that the outcome has been tested as proof of correctness. As a rule of thumb, you must keep in mind that testing may be only applied to discover errors but not to prove the correctness of this implementation. Be careful because according to a well-known paradigm there is always at least one more bug in each implementation in spite of intensive testing. Deep dive into testing is far beyond the course scope. During the course, I have limited usage of the testing to expose examples of features but not to prove the correctness of the code. Regardless of this, when the test result warns you about an error during testing, thanks to the layered program arrangement you are sure that the issue source is located inside your implementation of the layer or the testing implementation of the layer below. Let me stress that a bug if any is in your code where you should look for problems, not in the code of your teammate. For sure, testing only your stuff improves the performance of the debugging process.
 
 First, while testing the selected layer, we must remove dependency on the layer located just below the tested one. More precisely, we must replace dependency on the implementation of the layer below only,  by providing quite a new implementation for testing purposes only. In other words, the new testing implementation must replace the implementation developed for production purposes. It is a perfect example of polymorphism that requires layered architecture. We will get back to this topic again very soon.
 
-### 1.5.4. Technology Change Adaption
+### Technology Change Adaption
 
 It is obvious that technology will change over and over. It is a continuous process. So very vital question is how to be prepared for technological change. Layered architecture could be a real relief because we can replace only the affected layer after the technology change. It is especially important for the layers, which depend on the progress of technology, like data repositories, networking, and graphical interface resources.
 
-### 1.5.5. Scalability Leveraging
+### Scalability Leveraging
 
 The next good reason to apply the layered archetype is the possibility to make scalability and portability deployment easier. I will get back to this topic later but now as an example let me just mention the possibility to spread the layers execution to different computers or the necessity to change the execution platform.  This benefit is tightly coupled with the possibility to follow technology progress.
 
-## 1.6. Layers
+## Layers
 
-### 1.6.1. Introduction
+### Introduction
 
 Following this introduction let's use the separation of concerns concept to separate the program text into units, with minimal overlapping between the responsibility of the individual units. There are a lot of patterns that could be helpful to implement this idea of separation. One of them I mentioned as an example to define what is the problem, namely layers. Again, we will extensively explore this arrangement of the program as a very important one but keep in mind that it is only an example. So, let's get back to software engineering. You know that usually talking about a layered program we may distinguish three layers: the presentation, logic, and data layers as follows:
 
@@ -136,81 +92,81 @@ This design pattern on the screen (Fig. 1) is clear and doesn't need any special
 
 Figure 1. Layered program architecture
 
-### 1.6.2. Responsibility
+### Responsibility
 
 Talking about layers I am talking about responsibility but not about the functionality of the layer. The main reason is that responsibility is a commitment. It is only a promise. This term better suits the design process. Functionality may be recognized as a contribution to the behavior but it applies to run-time but not design time context. Writing a program as a result of the algorithm implementation process is design-time activity therefore I prefer to talk about design time. To be honest I don't think it has an impact on the program development methodology.
 
-### 1.6.3. Presentation Layer
+### Presentation Layer
 
 So, get back to the responsibility of layers description. The presentation layer is responsible to provide interaction with the program end user. Today, usually we are using a graphical user interface but not only. The computers may have many additional devices that we can use. For example, obviously, a screen to present any graphical information but also headphones to play music. There are many reasons why this layer should be separated as an independent unit, namely user interface flexibility, and technology dependence to name only the most important for now.
 
 This layer is also responsible for providing data using a natural language. It is a reason to implement this layer as an independent one. Hence, in this case, it should allow the possibility to replace the communication with the user without any impact on the rest of the program. It makes also the solution more flexible against general user interface requirements, for example, symbols, colors, and screen arrangement. It is not an easy task to deal with the user requirements because the representation is not formal so could be subject to many changes during the life cycle.
 
-### 1.6.4. Logic Layer
+### Logic Layer
 
 Just below the presentation layer, there is the logic layer. It is responsible for provisioning the main functionality implementation of the algorithm related to the process in concern. As I said previously, the algorithm is abstract knowledge, but we must implement it somehow. Here the main challenge we must face up is how to distinguish the main functionality from the rest.
 
-### 1.6.5. Data Layer
+### Data Layer
 
 The data layer is the bottom one in the architecture. The name could change but by design, the responsibility is always the same. The data layer is responsible for allowing access to the data managed using available local or remote resources. For example files, networks, or databases. Remote resources could be determined as relevant equipment for the distributed systems. The outline of the distributed systems is out of the course scope, so we may safely remove remote resources from the discussion. The same is with the connectivity over the network. Fortunately thanks to the program execution platform usually we may employ remote resources as local ones.
 
-## 1.7. Layers Dependency Rules
+## Layers Dependency Rules
 
-### 1.7.1. Presentation to Logic
+### Presentation to Logic
 
 To follow the layered program pattern the presentation layer uses only the logic layer. The relation is there (Fig 1.). It must be the top-down dependency relationship between these two layers and this relationship is unidirectional. For example, it is incorrect to put another arrow here and say that the logic refers also to presentation because it is against the layered pattern. In the case of a bidirectional relationship, it is hard to say that the presentation is above logic. So let's erase this arrow. Top-down is the only allowed direction. So first talking about the layers we must prove that we have a top-down unidirectional relationship between the layers. We must face up to answer the question, how to prove this when we are talking about the program? I will try to help you answer this question shortly.  the only thing I must stress now is that any program is a text. It is a sequence of characters compliant with a selected programming language. The language in turn is defined on a foundation of the alphabet, syntax, and semantic rules.  We must keep it in mind while discussing dependency relationships.
 
-### 1.7.2. Presentation to data
+### Presentation to data
 
 It is also not allowed to provide this dependency relationship (presentation => data) because in this case, we don't know if the layer below is logic or alternatively data from the presentation point of view because following the dependency relationship both are on the same level. Therefore it is also not correct. The only possibility is that the upper layer refers to the layer below and only the below one. It is the only correct relationship.
 
-## 1.8. Deployment Layers
+## Deployment Layers
 
-### 1.8.1. Layered Architecture of Program Text
+### Layered Architecture of Program Text
 
 First I must remind you that the algorithm development is far beyond the course scope. The main goal is to apply the separation of concerns rules directly to the text development but as a result of the implementation of the solution derived from a research process, shortly algorithm. The second observation is that to make the course practical we must apply the layered architecture to the program text but not to the thinking process. I propose to do it in the context of the selected language semantics. In spite that we are using a concrete development environment, the main hope is that this approach is easily portable to at least all the strongly typed languages. The examples have been added to the project `LayeredArchitecture`.
 
-### 1.8.2. Layered Architecture in Program Context
+### Layered Architecture in Program Context
 
 Earlier we already proved that layered program architecture is very beneficial and is derived from a general concept called separation of concerns. Simplifying, by design, the separation of concerns applies to the way of thinking, but as software developers, we need to implement it as an architecture of the program text. A program is just a text compliant with a selected programming language. In our case it is CSharp. Hence the architecture including the relationship of layers must be expressed using terminology defined by the language itself. In other words, talking about functionality is perfectly OK if we talk about the algorithm but not the program.
 
-### 1.8.3. CSharp as Language
+### CSharp as Language
 
 Languages offering object-oriented programming usually use types as a construct that takes responsibility to implement the algorithm in concern. Further discussion may depend on the selection of a concrete programming language. Therefore, according to the rules of the course the further discussion I will conduct using CSharp as the language and Visual Studio as the development environment. Check out the project to follow me in this respect.
 
-### 1.8.4. Layer as Group of Custom Type Definitions
+### Layer as Group of Custom Type Definitions
 
 From the examples gathered in the `LayeredArchitecture` project, it is easy to guess that I propose the implementation of a layer as a set of custom types definitions. In maths, sets are a collection of well-defined entities called members of a set. In the proposed case the well-defined entity is a custom type - a language construct. The set notion is derived from the mathematical theory and is well known from the background school education, hence we may skip dive into this theory. The only important thing is how to recognize the membership. There must be a boundary that we can use to distinguish if a type belongs to the selected set or not. To make the layer unambiguous it must be assumed that the type belongs only to one set. This way we can convert the discussion about mathematical stets to an examination of types grouping. On the screen, you can see a few custom definitions of types. That is `DataLayerAbstract`, `ServiceA`, and `View`. Now we must answer a question about recognizing the membership of groups called layers. In other words the fact of being a member of a selected group.
 
-### 1.8.5. Namespace as Set Boundary
+### Namespace as Set Boundary
 
 The namespace construct could be a relief to help answer this question. Namespaces are used to organize and provide a level of separation of program parts and to avoid name collisions. The namespace unique name could be used as a prefix of the definition identifier to make the definition name unique to the program scope. They can also be considered as a container that consists of definitions.  This concept perfectly fits the concept of definitions grouping or more formally enforcing set membership of types.
 
-### 1.8.6. Relationship Implementation
+### Relationship Implementation
 
 Collecting custom definitions using namespaces to implement layers as the program architecture is only the first part of the solution. We have to implement also unidirectional top-down relationship. In the case of treating customs definitions as members of a layer, it may be accomplished very easily because definitions are related to each other using bidirectional dependency relationships. It is your responsibility to limit the freedom of direction of the dependency of types definitions to follow the rules defined previously for layers.  Let me stress, to implement this hierarchical and layered architecture the definitions belonging to one layer should depend only on definitions belonging to the layer directly below.
 
-### 1.8.7. Selection of Layer Membership
+### Selection of Layer Membership
 
 So any discussion about the layers must be conducted in the context of definitions expressed as a text according to the selected programming language.  For example, the presentation layer must contain part of the program text responsible for the implementation of the user interface but the question is which one? Which part of the program should be aggregated by the presentation layer? Of course on the one hand it could be related to the main responsibility of this layer that at the end of the day it ensures required functionality at run-time. In the meantime, the responsibility must be implemented as a set of definitions organized and separated as one unit using namespaces. As we did prove previously it is very clear how to create layers using definitions grouped by namespaces. The real mystery of software development is the aggregation and separation of definitions to precisely cover the layers of responsibility.  Therefore working on an algorithm and its implementation is a process usually tightly coupled with others and needs an iteration approach.  Because responsibility and functionality are abstract terms it is very difficult to prove that we have aggregated all the appropriate functionality as layers. In summarizing, talking about layers we are talking about a set of definitions grouped together and separated from other layers using a namespace concept. I believe that this approach is pretty universal and easily portable to other languages.
 
-### 1.8.8. Abstract Layer Interface
+### Abstract Layer Interface
 
 To develop layers independently from each other, the development scope or responsibility of layers must be precisely defined to avoid implementation overlapping or gaps. More specifically at the end of the day, the independently developed layers must fit each other to fulfill the correct control flow from the upper layer to the layer below at run-time. The problem with simultaneous development is how to start working on the development of the upper layer without knowing how to pass the control to the layer below. To deal with that we must have a sort of contract derived from the layer below that is to be followed up by the upper layer. It must be abstract because we don't yet have an implementation of the layer below. According to the primary assumption, we have to consider that the development of the layer below is underway or even has not yet started. For the Logic layer, an example is located in the AbstractLayerInterface namespace branch.
 
-### 1.8.9. Applying Object-oriented Programming
+### Applying Object-oriented Programming
 
 The need to provide an abstract representation of a layer is a very good reason to apply object-oriented programming to accomplish it. The main idea behind the Object-Oriented Programming concept is encapsulation, abstraction, inheritance, and polymorphism. Let me stress that the mentioned above abstraction is one of them. How to apply abstraction depends on the programming language, but in most languages, I know we may use constructs like interfaces and abstract classes that may be used to deliver abstract definitions. By design, we can recognize abstraction as hiding the implementation details. It suits very well to our simultaneous development scenario because having abstract definitions makes independent implementation possible as a result of removing the dependence on the implementation of the layer below. How to realize the abstract interface of a layer you can investigate using the examples available in the mentioned above namespace branch AbstractLayerInterface.
 
-### 1.8.10. Inheritance and polymorphism
+### Inheritance and polymorphism
 
 There are next two very useful ideas behind object-oriented programming that are necessary to successfully deploy the layers concept, namely inheritance, and polymorphism. Inheritance is a mechanism where a new definition can be derived from an existing one to share the basics features or implement abstract definitions. Polymorphism is a concept that refers to the ability of an implementation to take on multiple forms. In our case, one form is for final, production purposes, and the second one is for testing purposes. The most important for us is that both forms, more specifically both implementations are derived from the same contract,  or using object-oriented programming terminology inherit the same abstraction to share the same features.
 
-### 1.8.11. Implementation for testing purpose
+### Implementation for testing purpose
 
 An example is in the `BusinessLogicTests` which pretends to test the Logic layer. To Test only the Logic layer the production version of the Data layer must be replaced by an implementation created for testing purposes only. This implementation is provided by the `DataLayerAbstractFixture` class. An instance of this class is injected - that is assigned - as an actual argument to the factoring method of the Logic layer.
 
-## 1.9. That's all for now
+## That's all for now
 
 That's all about the implementation of the algorithm using a layered program. To be honest, it could be done using the partial mesh approach (Fig. 2.) but thanks to layers the following benefits may be accomplished:
 

--- a/InformationComputation/LayersCommunication/README.md
+++ b/InformationComputation/LayersCommunication/README.md
@@ -1,49 +1,12 @@
-# 1. Inter Layer Communication
+# Inter Layer Communication
 
-## Table of content <!-- omit in toc -->
-
-- [1. Inter Layer Communication](#1-inter-layer-communication)
-  - [1.1. Topic introduction](#11-topic-introduction)
-  - [1.2. What is the problem?](#12-what-is-the-problem)
-    - [1.2.1. Communication](#121-communication)
-    - [1.2.2. Conclusion](#122-conclusion)
-  - [1.3. Introduction To Examples](#13-introduction-to-examples)
-  - [1.4. Program Architecture](#14-program-architecture)
-  - [1.5. Testing Methods](#15-testing-methods)
-    - [1.5.1. Introduction](#151-introduction)
-    - [1.5.2. User Interface](#152-user-interface)
-    - [1.5.3. Unit Tests](#153-unit-tests)
-  - [1.6. Methods Invocation](#16-methods-invocation)
-    - [1.6.1. Calling Method Provider Correct Sequence](#161-calling-method-provider-correct-sequence)
-    - [1.6.2. Calling Method Provider Wrong Sequence](#162-calling-method-provider-wrong-sequence)
-  - [1.7. Callback Based Bottom-up Communication](#17-callback-based-bottom-up-communication)
-    - [1.7.1. Bottom Layer of Callback Based Bottom-up Communication](#171-bottom-layer-of-callback-based-bottom-up-communication)
-    - [1.7.2. Upper Layer of Callback Based Bottom-up Communication](#172-upper-layer-of-callback-based-bottom-up-communication)
-  - [1.8. Event Based Bottom-up Communication](#18-event-based-bottom-up-communication)
-    - [1.8.1. Bottom Layer](#181-bottom-layer)
-    - [1.8.2. Upper Layer](#182-upper-layer)
-  - [1.9. Reactive programming](#19-reactive-programming)
-    - [1.9.1. Two Main Asynchronous Interactions](#191-two-main-asynchronous-interactions)
-    - [1.9.2. Top-down Communication](#192-top-down-communication)
-    - [1.9.3. ReactiveProgramming Preface](#193-reactiveprogramming-preface)
-    - [1.9.4. IObserver, IObservable interfaces](#194-iobserver-iobservable-interfaces)
-    - [1.9.5. Publisher](#195-publisher)
-    - [1.9.6. Subscriber](#196-subscriber)
-  - [1.10. Dependency Injection](#110-dependency-injection)
-    - [1.10.1. Dependency Injection Introduction](#1101-dependency-injection-introduction)
-    - [1.10.2. Dependency Injection - Problem Description](#1102-dependency-injection---problem-description)
-    - [1.10.3. Bottom Layer](#1103-bottom-layer)
-    - [1.10.4. Upper Layer](#1104-upper-layer)
-    - [1.10.5. Summary](#1105-summary)
-  - [1.11. See also](#111-see-also)
-
-## 1.1. Topic introduction
+## Topic introduction
 
 By design, the layered program architecture means its organizations, in which we can distinguish independent entities of a program related to each other making a top-down hierarchy. Usually, for all languages, an entity may be implemented as a set of declarations compliant with the selected programming language. Hence, the layered architecture may be implemented using these sets. The distinguishing feature of a layer is that all definitions belonging to a layer are self-contained internally in a layer or may refer only to the declarations visible from the layer below. In other words, the top-down relationship means that the layer above only refers to the declarations available by the layer below. We discussed it already stressing that it is a compile-time pattern. At run-time, we must consider control flow and data flow in both directions for sure. This lesson address the topic of how to implement bidirectional control and data flow using a unidirectional layered architecture. As usual, at the very beginning, we will enumerate the main problems we must face up.
 
-## 1.2. What is the problem?
+## What is the problem?
 
-### 1.2.1. Communication
+### Communication
 
 Layers must be interoperable. Interoperability is the ability of different program layers to cooperate with each other in a coordinated way. The layered program architecture was discussed earlier during this course. This lesson address inter-layer communication as a foundation of interoperability. In general, communication means sending or receiving information. In the context of an algorithm, communication may be recognized as the act of giving, receiving, and sharing information - in other words, talking or writing, and listening or reading. In the context of information computation, inter-layer communication may be considered as control flow, data transfer, and event notification.
 
@@ -53,37 +16,37 @@ Layers must be interoperable. Interoperability is the ability of different progr
 
 **Event Notification**: To avoid time-wasting poling to check if there is new data available, a notification operation must be enforced as a result of the assignment. Notification may be considered as an operation pushing a notice that a condition has been met. For example, notification that new data is available. Sometimes events are not coupled with additional data, for example, it is a case if we are waiting for the end of the computation and don't care about the computation result.
 
-### 1.2.2. Conclusion
+### Conclusion
 
 The main challenge we will face up is how to implement all of that using layered program architecture. We will talk about internal communication only avoiding touching the topics related to networking. To avoid further theoretical discussion let's analyze the available options that are provided by the selected programming language. I will try to make the examples portable to other development environments and also reusable in the context of communication over a network. Again, portability and networking are beyond the lecture scope and these topics must be covered by independent courses.
 
-## 1.3. Introduction To Examples
+## Introduction To Examples
 
 I have prepared a few examples to explain how control flow, data transfer, and event notification fulfill requirements of the bidirectional inter-layers communication. To make it as straightforward as possible, we will return to the example discussed in the dependency injection context. Let's assume that our task is to ship a library for an unknown in advance number of users. Additionally, we don't know where and how our library will be used. We only assume that it is the logic layer. The presentation and data layers have been added to make the examples more comprehensive. The examples to be investigated are located in the project `LayersCommunication`. We will use many communication patterns to validate the sequence of methods invocation. In other words, we will test the behavior of a program. The mentioned set of methods contains methods named Alfa, Bravo, Charlie, and Delta. The methods must be invoked in alphabetical order. Of course, in a production environment, we must provide only one implementation of this set but for the sake of example, we have independent implementations for proposed programming patterns.
 
-## 1.4. Program Architecture
+## Program Architecture
 
 We will analyze the proposals in the context of layered architecture presented in the following figure. The layers are created using namespaces Presentation, Logic, and Data. For sake of simplicity they are gathered in one project. The namespaces are named after the folders in the project. This architecture, as expected uses layers interconnected by the unidirectional top-down relationships. The namespaces play the role of the declaration sets. I must stress, this architecture has nothing in common with the layers communication but shows only the dependency hierarchy of definitions gathered in namespaces. If you haven't done it yet clone the repository and check out the solution to learn more about the details. I will refer to details during further discussions and conclusions related to the proposed patterns. Again, let me recall that our challenge is to show how to implement interoperability of layers created using unidirectional dependency relationships based on bidirectional communication.
 
 ![Application Architecture](.Media/LayersArchitecture.png)
 
-## 1.5. Testing Methods
+## Testing Methods
 
-### 1.5.1. Introduction
+### Introduction
 
 To make the examples self-contained and as simple as possible they are gathered in one executable project. The presentation layer contains the command line user interface. It is not a typical approach but in this solution, it is used to log the program behavior. As an alternative, unit tests gathered in another project called `LayersCommunicationTest` are provided.
 
-### 1.5.2. User Interface
+### User Interface
 
 A user interface that engages the command line operating system window is implemented in the internal static class Program. It is used to generate a screen log tracing the behavior of the program. For the purpose of the production environment, you should consider moving this layer from the library to a separate project if any. After executing the program a text like this should appear on the screen. I have attached to the project a markdown file containing this result. A user interface is provided only to mimic the existence of the presentation layer. For us, the only interesting point is that this layer refers only to the layer below using abstract definitions.
 
-### 1.5.3. Unit Tests
+### Unit Tests
 
 To mimic the existence of the presentation layer, another approach is the engagement of the unit tests against the logic layer. As usual, we will apply the unit test to extract and illustrate the usage of the most important patterns applied to implement inter-layer communications. Of course, partially the unit tests gathered in the project that is named  LayersCommunicationTest after the previously mentioned project in concern. As previously, all tests refer to only abstract definitions exposed by the logic layer as a public interface named ILogicAbstraction. Using an access modifier we can control the visibility of the declarations outside of the project. Without any additional tools, this way we can control which definitions make up the program layer interface (PLI). That is the set of definitions used by the layer above to interact with the layer below. Additionally, we can assure that the dependency is one way only. Unit testing has much more advantages but now we are not talking about software diagnostics but about communications of layers. So let's get back to the communication patterns you can reuse for this purpose.
 
-## 1.6. Methods Invocation
+## Methods Invocation
 
-### 1.6.1. Calling Method Provider Correct Sequence
+### Calling Method Provider Correct Sequence
 
 Implementation of the inter-layer bidirectional communication using method call is available since the very beginning of the software engineering era. A method is a named block of code that contains a sequence of statements or instructions. Terminology depends on the language syntax. In this pattern, the upper layer has to invoke the methods defined in the layer below. It causes the execution of the sequence of statements. While calling a method all required arguments must be provided. Execution of the sequence of statements must be recognized as top-down flow control. Assignment of the actual arguments to the formal arguments fulfills data transfer needs. Formal arguments play the role of variables holding the values provided during the method call. Argumentless methods could be used to notify the layer below by the upper one that a condition is met. This synchronous call of methods is perfect for the implementation of top-down communication but it is irreversible. To implement bottom-up data transfer we may only use ref arguments, out arguments, and return values to transfer data to the upper layer from the layer below provided that the data type is standard or defined as a member of the layer below. Exactly this approach has been used in the CheckConsistency method call statement.
 
@@ -95,81 +58,81 @@ Assert.IsTrue(callingMethodProvider.CheckConsistency());
 
 In this line of code, we are expecting that the method returns true because the methods call sequence is correct in this example.
 
-### 1.6.2. Calling Method Provider Wrong Sequence
+### Calling Method Provider Wrong Sequence
 
 Returning false in the previous example is not informative enough because for all of the possible errors the result is always the same. Hence, it doesn't provide enough diagnostic information that can be used to improve the code and avoid similar problems in the future. Partially we can overtake this by throwing an exception in the layer below to notify the layer above that there is an unexpected condition. Contrary to many descriptions, an exception is just a class derived from the standard Exception class but not an event or notification. Hence, an instance of the exception may also be used to transfer data up to the upper layer. In almost all programming languages we have special instructions to throw an exception. Usually, it is a kind of goto instruction with a parameter, which must be an exception class instance. The main drawback of this kind of control flow and data transfer is that using the throw instruction should be a kind of last resort. According to the widely accepted best practice rule, throwing an exception is allowed only and only if the continuation of execution of the instructions sequence doesn't make sense and as the result, it must be broken and handled somewhere earlier in the call chain. For more details related to the behavior of the throw instruction and exception concept visit the user guide of the selected programming language. Concluding, sometimes the throw instruction may be classified as communication implementation but it must not be used as a regular communication behavior. We need to improve the methods call to implement inter-layer communication. It is worth remembering that the rest patterns I am going to discuss are derived somehow from the concept of the method invocation concept.
 
-## 1.7. Callback Based Bottom-up Communication
+## Callback Based Bottom-up Communication
 
-### 1.7.1. Bottom Layer of Callback Based Bottom-up Communication
+### Bottom Layer of Callback Based Bottom-up Communication
 
 The next option for implementation of the bidirectional inter-layer communication founded on the unidirectional layer relationship is the callback method concept. In general, a callback method is a method passed into another method as an argument, which is then invoked to complete a sequence of instructions. Invocation of methods using variables - precisely speaking formal arguments - you can find in the CallBack class. A sequence of instructions may be called by the layer below at any time bottom-up communication is required. This way we can implement bottom-up notification and control flow. Because while invoking a method all its current parameters must be provided also data transfer is possible. It is worth stressing that at the very beginning of this concept a method is treated as data. Therefore, we need a special type that allows defining a set of allowed values and using it to prefix a variable. This approach needs programming language support and depending on the language different terminology may be used. For CSharp, we have a delegate type. An example defined for the example purpose is TraceDataDelegate. The type declaration determines allowed values by specifying the signature of the methods. The delegate value is a set of references to methods that have a common signature predefined for the delegate type. In this approach instead of using a method name to invoke the aggregated functionality, we are using a variable current value. It is worth stressing that in the place a method is invoked we know only its signature but not the actually implemented functionality. In our example, the functionality is defined in the upper layer.
 
-### 1.7.2. Upper Layer of Callback Based Bottom-up Communication
+### Upper Layer of Callback Based Bottom-up Communication
 
 As previously the upper layer implementation you may be found in the presentation layer located in the main project called LayersCommunication or in the unit tests project called LayersCommunicationTest. Let's investigate only the second example located in the CallBackUsage test class where you may find the invocation of methods in concern. An example of the method compliant with the signature declared for the mentioned above type is the TraceData instance method declared as a member of the InMemoryTraceSource instrumentation class. Finally, we can fulfill all needs of bottom-up communication by invoking a diagnostic method using delegates. Because this way method becomes data we may also preserve it for future use detaching the callback from the assignment of a variable.
 
-## 1.8. Event Based Bottom-up Communication
+## Event Based Bottom-up Communication
 
-### 1.8.1. Bottom Layer
+### Bottom Layer
 
 Events are a very popular form of callbacks. Using the event-based approach, we will try to examine this mechanism to implement bottom-up inter-layer communication. The TraceDataEvent is of the delegate type. It means that it is a variable and it may contain a set of references to methods that shall be invoked to notify that the layer Logic encountered an expected condition and is willing to inform all interested parties by invoking the methods added to this set. Making this variable visible in the upper layer allows assigning a delegate referencing a method supplied to notify the condition. All methods that are members of this example use the variable TraceDataEvent to invoke the methods provided that the set is not empty. Invoking a method means at least bottom-up notification and control flow. Parameters of the methods may be used for data transfer. As far as now the proposed pattern resembles the previous example. The only syntax difference is that the delegate variable TraceDataEvent is prefixed by the keyword event. To explain the semantics difference we must again refer to the type concept. All types including delegates define a set of values and a set of operations that may be applied to values belonging to the type. For all types except the delegates, the keyword used to declare the visibility of a variable applies to all operations defined by this type as well. Using the keyword event introduces a selective availability policy that restricts the scope of some operations visibility. For example, the invoke operation can only be executed inside the class where the event is declared. The main reason is to improve robustness by distinguishing and clearly separating the publisher and consumer roles. As the name says, the publisher is recognized as a class that is a source of communication realized using events. Therefore, only inside this class, we can invoke the methods referenced by the event variable. It means that we can consider the invoke operation as always private despite the accessor prefix of the variable. Subscribers express their willingness to be a destination of the communication by adding a reference to a method that can be used as a starting point to consume the communication outcomes. This relationship multiplicity is one too many.
 
-### 1.8.2. Upper Layer
+### Upper Layer
 
 The subscriber functionality consuming the event exposed by the EventBased class we may find in the presentation layer located in the main project called LayersCommunication or in the unit tests project called LayersCommunicationTest. Let's investigate only the second example located in the EventBasedUsage test class where you may find the invocation of methods in concern. In this line, we are creating a delegate value that refers to the TraceData, which is the instance method of the InMemoryTraceSource class. After that reference of the method as a delegate, a value is added to the set that is holden by the TraceDataEvent variable. By invoking the CheckConsistency instance method of the same object we are proving that all the methods in concern have been invoked in the expected sequence. If not the test method fails.
 
-## 1.9. Reactive programming
+## Reactive programming
 
-### 1.9.1. Two Main Asynchronous Interactions
+### Two Main Asynchronous Interactions
 
 Returning to the previous discussion, we shall notice that while talking about inter-layer communication, we can distinguish two main intentionally asynchronous interactions. I mean top-down and bottom-up communication. Communication is an operation observed at run time but it must be implemented at the design time of the program life cycle. In all scenarios for layered architecture, to implement bottom-up communication top-down communication is required for the layered program archetype.
 
-### 1.9.2. Top-down Communication
+### Top-down Communication
 
 At least the top-down communication is required to express a willingness to receive messages by the upper layer, I mean to be notified by or receive data from the layer below. Operations that express this we call subscriptions. Finally, it leads to the publisher-subscriber interoperability pattern where senders of messages, called publishers, do not send them directly to specific receivers, called subscribers, but instead, categorize published messages into classes without knowledge of which subscribers if any, there may be.
 
 Similarly, subscribers express interest in one or more classes and only receive messages that are of interest, without knowledge of which publishers, if any, there are. There is no tight relationship between the Subscribers and Publishers, the Subscriber must deal with this issue in a reactive rather than proactive way.
 
-### 1.9.3. ReactiveProgramming Preface
+### ReactiveProgramming Preface
 
 Concluding, reactive communication allows the implementation of a design pattern that relies on asynchronous programming logic to handle incoming updates by the upper layer. It allows the implementation of a mechanism for receiving push-based notifications. Using the examples gathered by ReactiveProgramming we will investigate this approach to implementing inter-layer bottom-up communication based on reactive programming.
 
-### 1.9.4. IObserver, IObservable interfaces
+### IObserver, IObservable interfaces
 
 Implementation of the reactive communication pattern is founded based on the IObserver, and IObservable interfaces. The IObservable interface requires an implementation of the Subscribe method by the publisher. This method shall be invoked to announce a willingness to receive data compliant with the selected type. The class derived from the IObserver that plays the role of the subscriber shall implement three methods: OnNext to push new data by the publisher, and OnError to notify about an error. If a publisher wants to notify that there is no more data to push it invokes OnCompleted. To unsubscribe an IDisposable object returned from the Subscribe method is used.
 
-### 1.9.5. Publisher
+### Publisher
 
 In the snipped of Reactive Programming, the event concept has been reused making this example comparable to the example based on the event concept foundation only. As an implementation helper, the Observable static class is engaged. To meet our needs each call to methods offered by the ILogic interface triggers an event and finally, it is converted to the appropriate method invocation available from the Observable class implementation.
 
-### 1.9.6. Subscriber
+### Subscriber
 
 I used the ReactiveProgrammingTestMethod to subscribe to the publisher defined previously as a part of the logic layer. The method is located in the LayersCommunicationTest project. You may also check out the Program static class located in the presentation layer to investigate the usage of the ReactiveProgramming class for communication. This unit test shall be considered as an upper layer located just above the logic layer. The test invocates all the methods in concern declared by the ILogic that shall be considered as production stuff. We are expecting that all invocation of the methods Alpha, Bravo, Charlie, and Delta will cause a notification in the InMemoryTraceSource object. After finishing the subscription is canceled using Dispose method instance method of an object returned from the Subscribe method. As previously, the correct sequence of invocations is checked by the CheckConsistency method. In this example, the onNext parameter is implemented as a delegate using the anonymous function concept we have discussed already. The parameters onCompleted, and onError are not used for the sake of simplicity.
 
-## 1.10. Dependency Injection
+## Dependency Injection
 
-### 1.10.1. Dependency Injection Introduction
+### Dependency Injection Introduction
 
 Dependency injection is the next pattern that can be engaged to implement bidirectional inter-layer communication preserving the top-down layer design time relationship. The main point of this pattern is an assignment to an abstract variable a reference of an unknown type that is derived from this abstraction and which cannot be instantiated locally for some reasons. I named this pattern dependency injection to somehow distinguish the situations of using just object-oriented programming alone. In this scenario, we are using object-oriented programming to deal with the separation of concerns. One concern is the usage, and the second one is the implementation of a concrete type. Hence, shortly the dependency injection is a pattern where we are using an unknown for some reason type that is represented by an abstraction. The abstraction is used in the lover layer where concrete type definition must not be located for some reason. Previously we analyzed polymorphism as the main reason to move the definition to independent assemblies. Now we consider moving the type definition to the upper layer to follow the separation of concerns rule. Again in this example, we are applying the object-oriented programming concept to use abstraction instead of a concrete type because the type is not visible at all or must not be referenced for some reason.
 
-### 1.10.2. Dependency Injection - Problem Description
+### Dependency Injection - Problem Description
 
 As an example we have the same goal as previously, namely monitoring the sequence of calling the methods belonging to a selected class called DependencyInjection, which implements the  ILogic interface. This interface contains declarations of methods signatures in concern. This example is located in the logic layer of the project LayersCommunication. Previously we did discuss a similar example but it was forked to two independent classes called PropertyInjection and ConstructorInjection to stress options related to how to pass a reference to an object. In the considered example, a mixture of the constructor and property approaches implementation is presented but the functionality is exactly the same.
 
-### 1.10.3. Bottom Layer
+### Bottom Layer
 
 In this example we are using an abstraction called ITraceSource instead of a concrete type because its implementation must be located in the upper layer or in an independent assembly so cannot be referenced directly to avoid bottom-up layers dependencies and circular references between assemblies. We are expecting that all invocation of the methods Alpha, Bravo, Charlie, and Delta will cause a notification in an object referred to by the variable TraceSource. To implement this all invocation of the mentioned methods cause invocation of the TraceData method to push the notification and diagnostic data. Invocation depends on the evaluation of the TraceSource variable. As a result of the null-conditional operator, if the variable evaluates to null nothing happens, that is all invocation of the instance methods defined by the ITraceSource are skipped.
 
-### 1.10.4. Upper Layer
+### Upper Layer
 
 The bottom-up communication provider consuming the notifications and data generated by the bottom layer we may find in the presentation layer located in the main project called LayersCommunication or in the unit tests project called LayersCommunicationTest. Let's investigate only the second example located in the DependencyInjectionUsage test class where you may find the invocation of methods in concern. In this line, we are creating an object of InMemoryTraceSource type, which implements the abstraction ITraceSource interface defined by the bottom layer which is Logic in this case. After that, a reference to it is pushed to the instance of DependencyInjection class initialized using constructor or property injection approaches. In the case of property injection, after creating an object in concern we need to remember to assign the reference of an object responsible for further diagnostic data processing. In the case of constructor injection, we are obtaining only an object that can be represented as an ILogic interface that can be used to invoke the methods in the testing process. In both cases, by invoking the CheckConsistency instance method we are proving that all the methods in concern have been invoked in the expected order. If it is not true the test method fails.
 
-### 1.10.5. Summary
+### Summary
 
 Shortly, the dependency injection is a pattern we must apply in any scenario where we cannot use the new operator to create an instance of a reference type in the location where we are going to use the object because the type is or has to be unknown for some reason. To solve this problem we must employ the object-oriented programming concept. Thanks to object-oriented programming we can use abstraction by the event producer and move the implementation of this abstraction to a consumer. Because using an abstraction we are invoking a method that comes, that is implemented in an object provided from outside we may use the term inversion of control to name this pattern.
 
-## 1.11. See also
+## See also
 
 - [IObserver\<T\> Interface](https://docs.microsoft.com/dotnet/api/system.iobserver-1?view=net-6.0)
 - [IObservable\<T\> Interface](https://learn.microsoft.com/dotnet/api/system.iobservable-1?view=net-6.0)

--- a/InformationComputation/ObjectOrientedProgramming/README.md
+++ b/InformationComputation/ObjectOrientedProgramming/README.md
@@ -1,41 +1,12 @@
-# 1. Object-oriented programming
+# Object-oriented programming
 
-## Table of content <!-- omit in toc -->
-
-- [1. Object-oriented programming](#1-object-oriented-programming)
-  - [1.1. Preface](#11-preface)
-  - [1.2. What's the problem?](#12-whats-the-problem)
-    - [1.2.1. Lesson Scope](#121-lesson-scope)
-    - [1.2.2. Complex Data Custom Structure](#122-complex-data-custom-structure)
-    - [1.2.3. Polymorphism](#123-polymorphism)
-    - [1.2.4. Invisible types](#124-invisible-types)
-  - [1.3. Structural Types](#13-structural-types)
-    - [1.3.1. Introduction](#131-introduction)
-    - [1.3.2. Object-oriented Programming Theory](#132-object-oriented-programming-theory)
-    - [1.3.3. Looking For Language Constructs](#133-looking-for-language-constructs)
-    - [1.3.4. Objects Graph](#134-objects-graph)
-    - [1.3.5. Diamond Pattern](#135-diamond-pattern)
-    - [1.3.6. Information Model versus Object Model](#136-information-model-versus-object-model)
-  - [1.4. Polymorphism](#14-polymorphism)
-    - [1.4.1. Polymorphism as a problem](#141-polymorphism-as-a-problem)
-    - [1.4.2. Pillars of the Object-Oriented Programming](#142-pillars-of-the-object-oriented-programming)
-    - [1.4.3. Inheritance (Segment)](#143-inheritance-segment)
-    - [1.4.4. Abstraction (`ObjectOrientedProgrammingFundamentals`)](#144-abstraction-objectorientedprogrammingfundamentals)
-    - [1.4.5. Abstract Class](#145-abstract-class)
-    - [1.4.6. Interface](#146-interface)
-    - [1.4.7. Polymorphism (AdditionalAssertions)](#147-polymorphism-additionalassertions)
-    - [1.4.8. Calling Abstract Method (SC)](#148-calling-abstract-method-sc)
-  - [1.5. Invisible Types (SC AdditionalAssertions)](#15-invisible-types-sc-additionalassertions)
-    - [1.5.1. Problem description](#151-problem-description)
-    - [1.5.2. Interface Users Roles](#152-interface-users-roles)
-
-## 1.1. Preface
+## Preface
 
 In my opinion, a key to understanding the course is a good understanding of the object-oriented programming concept. Hence, I gonna spend a short amount of time recalling this concept. I will remind you of such object-oriented programming terms as class,  interface, inheritance, implementation, polymorphism, etc. I will pay special attention to the constructs that are characteristic of these terms for example abstract and virtual members. I want to stress that not all programming languages provide exactly the same constructs but we can find many similar ones, so my hope is that this discussion will also help to reuse the knowledge and port it to other languages if needed. We will come back to this topic many times throughout the course.
 
-## 1.2. What's the problem?
+## What's the problem?
 
-### 1.2.1. Lesson Scope
+### Lesson Scope
 
 - Custom structure of data
 - Polymorphism
@@ -43,86 +14,86 @@ In my opinion, a key to understanding the course is a good understanding of the 
 
 Usually, while learning of a new programming concept from a typical user guide, we may find an entry statement like this if you need object-oriented programming you may use class and interface constructs. I propose an opposite approach to learning the object-oriented programming concept. I will start defining real problems that can be solved using this programming concept. And based on this concept you will have an opportunity to better understand this concept without dip dive into the programming language details. My priority is to improve your understanding of this software engineering concept because I believe that it is a foundation for further deployment and portability of this concept to other development environments.
 
-### 1.2.2. Complex Data Custom Structure
+### Complex Data Custom Structure
 
 The first problem we could encounter is how to process complex information composed using parts interconnected by associations according to a custom pattern. This way we must deal with a graph of entities where both the value of entities and the shape of the graph are meaningful in the context of the information processing process. For example, typical shapes we must deal with are streams, trees, stacks, and diamonds to name only a few. Usually, programming languages support selected complex types representing the typical relationships between parts, like arrays, and records. Thanks to that the relationship between these parts is well known in advance a default selector operation can be defined. To select and process a part (value) contained by the array an indexer can be used. In C#, the record concept is implemented as the class or structure types. In this case, it is possible to select the member of a complex value using dot operation and the identifier of the member that must be unique in the context of the type - in this case, we are using a qualified name. To deal with any custom pattern that is not directly supported by the programming language we may apply object-oriented programming to implement structural types. Structural type means that using object-oriented programming we can model any pattern we need to implement an algorithm in concern. I used the word "model" instead of "create" because at design time we may only define types that may be used to create a graph at run-time using this model. From the examples - I am going to discuss - we will see that the pattern is only a template, it is only a limitation, and may be recognized as a bit of advice for further processing. Because the structure is also subject to be designed there is no one generic selection operation, hence instead of selecting we are using a browsing operation.
 
-### 1.2.3. Polymorphism
+### Polymorphism
 
 The second typical problem we must deal with is the ability of an entity to have more than one form like a drawing that at the same time may be a circle, square, or rectangle to name only a few simple shapes. Depending on the form we have to consider different representations of the drawing. This multiformity should allow us to perform a single action in different ways, for example, the area calculation must be performed in different ways for mentioned shapes but always yields just a number. Commonly this heterogeneity we call polymorphism. Polymorphism is a Greek word that means multiformity or multi-form. I wanna stress that this way we are recognizing polymorphism as a feature of the algorithm to be implemented but not a goal to be achieved. To implement a polymorphic algorithm we need appropriate tools and technics. Again object-oriented programming concept is the best-suited proposal we know today that fulfills our needs in this respect. In other words, type, abstract and virtual members of a class are the foundation for polymorphism implementation. Based on the examples we have in the repository, I will try to explain this issue in more detail.
 
-### 1.2.4. Invisible types
+### Invisible types
 
 Last but not least issue, which we may encounter while developing a computer program is a lack of the type definition that we should refer to. A typical scenario where we may face up this problem is working as a team. It allows us to spread the work between team members, and it could happen that the type is designed by one member and used by other ones. It causes that we must deal with two roles designer and user of a type. If the designer is late in time the user should not wait. Therefore we must look for solutions allowing us to postpone implementation while working in a multi-member team.  Again object-oriented programming concept is well suited to be a foundation for solving this issue. Again I will explain details using examples from the repository attached to this course.
 
-## 1.3. Structural Types
+## Structural Types
 
-### 1.3.1. Introduction
+### Introduction
 
 At the very beginning, I wanna recall object-oriented programming concept fundamentals. I assume that it is not your first touch with this concept and you have background knowledge or some experience related to object-oriented programming learned during the course on introduction to programming or programming fundamentals. Today most programming languages support this concept somehow. This concept is also addressed by a vast variety of independent courses. Therefore, we start our journey in the context of the first problem, namely how to apply object-oriented programming to finally make it possible to create a graph of objects according to a custom pattern.
 
-### 1.3.2. Object-oriented Programming Theory
+### Object-oriented Programming Theory
 
 Object-oriented programming is considered a paradigm according to which the information processing algorithm is implemented using a graph of objects. Since we have a graph, it means that the objects - parts of the graph - are interconnected by relations, so they may create a custom structure. Objects do not have unique names, hence the only way to select one of them is to use these relationships to perform selective access operations. The navigation of the graph using these relationships is called browsing. However, the lack of the need to use unique names allows you to create objects freely as needed and attach them to the graph. From the point of view of the implemented algorithm, the object is a representation of the information under processing and functionality that can be applied to process this information representation - it means data. The objects are created in compliance with selected types. It means that any object may be an active element, I mean, operations may be associated with it.
 
-### 1.3.3. Looking For Language Constructs
+### Looking For Language Constructs
 
 This is a theory that has evolved a lot over the past years, so please treat this lesson as a shortcut rather than an introduction to a serious discussion about object-oriented programming. This discussion is important here on how these principles of object-oriented programming were implemented in CSharp because some of them are crucial for further discussion. Here it should be noted that object-oriented programming talks about objects that are created in order to implement the algorithm. If we are talking about objects inevitably we are talking about the run-time phase of the program lifetime, not its design time for sure. So this is the result of the programming process, which in the previous lesson we defined as the process of creating text according to the rules of a programming language, so CSharp in our case and in these categories, you have to look for relationships. Well, this is the design phase of the program, not the execution phase. So the task is as follows. We are looking for language constructs that we will use in the design phase of the program, in order to obtain the effect during the run-time phase as described previously, i.e. the object-oriented programming paradigm.
 
-### 1.3.4. Objects Graph
+### Objects Graph
 
 Since in the execution phase we are going to obtain a structure of objects in which the objects are related to each other by associations, we have to talk about reference data. As we know from the previous lesson, data is formally described by types. The flagship representative of the reference type group is, of course, the class. Class definition, type declaration, and the `new` keyword allow you to create dynamically objects as needed and assign references to build practically any structure of objects at run-time. A reference is a one-way association that can be used to selectively access objects, I mean the components of the structure - components of the graph. Since a class is a type, it is a linguistic construct that allows you to define a set of allowable values ​​and operations on them. This fulfills the other requirements of the object-oriented programming paradigm outlined above. We'll discuss others in the context of CSharp to avoid any general and abstract discussion.
 
-### 1.3.5. Diamond Pattern
+### Diamond Pattern
 
 Using object-oriented programming we can create practically any structure of objects at run-time. Let's see how it works on a concrete example. In this example of classes, a diamond pattern has been implemented as a set of classes. This pattern is not very popular but I selected it because it is well defined. Suppose that the final graph is to contain four interconnected nodes, named top, left, right, and bottom. The nodes have been implemented using the classes with names resembling positions in the pattern. Finally, the shape like a diamond may be instantiated. Check out the unit tests to learn how the diamond graph of objects is instantiated at run time. Not always objects structure at the run time must be exactly the same as a structure of classes related to each other. Partially this issue may be overcome. In the examined example the constructor requires arguments pointing to the appropriate nodes depending on the planned position in the graph.
 
 ![Diamond Information Model](DiamondInformationModel.png)
 
-### 1.3.6. Information Model versus Object Model
+### Information Model versus Object Model
 
 Classes related to each other, followed by the objects that are their instances, make it possible to build an information model. Because at run-time, it contains a graph of objects it may be called also an object model. Sometimes we can get an opinion that the object model is an information model expressed using the object-oriented concept. I propose to skip this academic discussion. Here we must only notice that in spite of the model name (I mean relationships) placeholders for references to create a demanded pattern are added to the types at design time. At run time we have to deal with an instance of the information model instantiated as a graph of objects. This information model instance may be modified dynamically - I mean on demand, at any point in time - by adding and removing objects to the graph using references. In other words, dynamically means that the graph could change in time according to the needs as a result of information processing at run-time but it cannot be called dynamic programming. My point is that dynamic programming refers to situations where we must deal with unknown types in advance at design type. In this approach, the information model that is formed at the design time may be used as the graph pattern at rub time. Let me now stress that an unknown type doesn't mean an invisible type. Unknown type means that we need to discover type at run-time. Invisible type means that the type definition exists somewhere in the program but it is inaccessible for some reason. This scenario will be discussed letter during this lesson.
 
-## 1.4. Polymorphism
+## Polymorphism
 
-### 1.4.1. Polymorphism as a problem
+### Polymorphism as a problem
 
 Sometimes we must deal with the ability of an entity to have more than one form. For example, a drawing that at the same time may be a circle, square, or rectangle to name only a few simple shapes a person who at the same time can have different characteristics, like a man that at the same time is a father, a husband, and an employee. Depending on the form we have to consider different representations of it, I mean different data that is relevant for the processing in concern. It also has behavioral consequences. This multiformity should allow us to perform a single action in different ways. Commonly this heterogeneity we call polymorphism. Polymorphism is a Greek word that means multiformity. I wanna stress that this way we are recognizing polymorphism as a problem to be implemented. To implement polymorphism in the algorithm we need appropriate tools and technics offered by the programming language. Again object-oriented programming concept is the best proposal we know today, especially abstract and virtual members are the basis for polymorphism.
 
-### 1.4.2. Pillars of the Object-Oriented Programming
+### Pillars of the Object-Oriented Programming
 
 To promote a practical approach during this course, I will investigate details of the object-oriented programming concept and its features using examples you may find in the file `ObjectOrientedProgrammingFundamentals`. Inheritance, encapsulation, and abstraction are primary pillars of the object-oriented programming concept. Inheritance enables you to create new classes that reuse, extend, implement, and modify the behavior defined in other classes. The class whose members are inherited is called the base class, and the class that inherits those members is called the derived class. A derived class can have only one direct base class. Hence, polymorphism can be implemented by defining more than one derived class from a base one. As a result, polymorphism is often referred to as the next pillar of object-oriented programming although it is an effect of inheritance from the same base. Encapsulation refers to the ability of definitions to hide the visibility of the properties, methods, and other members that intentionally must not be referred to from outside of this definition. Last but not least is the abstraction which is a definition whose some members don't have an implementation part.
 
-### 1.4.3. Inheritance (Segment)
+### Inheritance (Segment)
 
 You may find an example where the inheritance is used in the file `Segment`. It contains a definition of a base class called Coordinates and a definition of the derived class called Segment. The Segment class reuses the x, and y fields defined in the base class and extends it by adding the NextSegment property. Next time I will provide examples of how to implement and modify the base type in the derived type. From this example, we can learn that the constructor is not inherited but the constructor of the base class must be called by the constructor of the derived class. Examples of how to use these types we can find in the unit tests project. Operator new creates an instance of the selected type and calls the constructor to set up the internal state of this instance. The instance is called an object and is stateful. Again the constructor is not called to create a new object but to set up it instead. The local variable `first` is responsible to hold the reference to the first object in the created sequence where each object knows which is the next one. For all reference types, we have a common constant `null` that can be assigned to a variable to point out that there is no associated object. Assigning a null value means that the variable is not pointing to any object. Exactly this case can be observed in line 24. In other words, if the object doesn't point to the next one it means that the object is the last in the stream. It is worth stressing that at design time we have only one single type, but at run time we can use this type to instantiate a stream with an unlimited number of objects interconnected to create a stream. Second observation refers to the possibility to process independently members of an object.  The class type is a kind of record and to select a member we can use the dot operator and the member name that must be unique in the class context. For example, this qualified name is used as the selector in lines 26 and 27. Because the objects have references instead of unique names hence to select an object member we must use browsing instead of qualified names. An example of browsing, we have in lines 35 and 36.  Take care that the browsing makes sense only if all values in the chain are not null.
 
-### 1.4.4. Abstraction (`ObjectOrientedProgrammingFundamentals`)
+### Abstraction (`ObjectOrientedProgrammingFundamentals`)
 
 In the previous example, we used inheritance to extend a base type definition by adding new members. Having inheritance we can consider the next option that allows us to modify existing members defined by the base type. To make a member of the base class ready for modification by the derived class it should be preceded by the `virtual` keyword. This notification allows us to override it in a derived class. It is important for further discussion on object-oriented programming that apart from the mentioned one we can distinguish the next two special kinds of modifications of the existing definition, namely replacement and implementation. To replace a member we can use the `new` keyword as a declaration modifier. The new keyword explicitly hides a member that is inherited from a base class. The abstract modifier indicates that the base definition member doesn't have implementation at all. In CSharp, we have two constructs that allow abstractions to be declared, namely the abstract class and the interface. An example is located in the file `ObjectOrientedProgrammingFundamentals`. Concluding, abstract and virtual members are the basis for polymorphism.
 
-### 1.4.5. Abstract Class
+### Abstract Class
 
 An abstract class is a definition that intentionally doesn't provide all implementation details and must be extended or modified by derived classes. Abstract members can only be used in an abstract class. An example of the abstract definition is an abstract method that does not have a block. The block is provided by the derived class that is inherited from it. An abstract class can have both abstract and regular methods. There are many reasons why abstraction could be useful for program design. My point is that the most important thing for abstraction is that as a result, we can split usage of the definition and its implementation for example to allow polymorphism. In other words, based on the abstract definition the only operation we cannot do is object creation at design time. We will get back to this issue later. By polymorphism, I mean two or more implementations of the same abstract definition. In other words, the final behavior depends on the implementation provider. It could also allow postponing implementation while working in a multi-member team.  Let me stress that the impossibility to use the abstract definition to create objects is a result but not a goal of abstraction. Think about the abstract definition as it is something not finished yet. Anyway, it means that the abstract class definition is restricted and directly cannot be used to create objects during the program execution phase because the expected algorithm must be implemented to be executed. This can only be ensured by creating objects from concrete types, so only objects with all implementation details can be instantiated. In the considered example for this abstract class, it is necessary to declare a new type derived from it that provides the implementation. In the newly created concrete class, all abstract declarations must be refined in such a way that the missing implementation details are provided. In our case, the block is missing in the **...** method, which is added here to the signature of the inherited method from the abstract definition. Again, we call this process implementation of the abstraction. As a side note, a block is a sequence of instructions separated by a semicolon - sometimes it is also called body for some reason.
 
-### 1.4.6. Interface
+### Interface
 
 By design, the interface is a language construct that allows us to define an abstract type. It contains declarations for a group of related members that a non-abstract class or a struct must implement. The interface members are by default abstract and public.  This concept was slightly expanded in the new language version but still, it should be recognized as an announcement of further implementation in the derived types.  Abstract class and interface both provide abstract declarations. By abstract declarations, I mean an incomplete definition of implementation details. The abstract class members can be modified and implemented by derived classes. Derived classes that aren't abstract themselves must provide the implementation for any abstract member from an abstract base class. On the other hand, the interface members can only be implemented by derived structures and classes. Therefore the interface is not only part of the object-oriented programming concept implementation using the reference types. It allows us to apply inheritance, and as a result, engage polymorphism also using value types. It could be used as a contract atop which value types have to be defined. It is worth noting that interfaces cannot be used to create objects but they can be used as a type of variable.  One of the reasons is that Interface methods do not have a block (body) - the block has to be provided by the classes that implement the interface. Implementing an interface you must fully define all of the members declared by the interface. An interface cannot contain a constructor as it cannot be used to create objects. Simplifying we may say that an Interface has only declarations - it is like an announcement of further implementation in the derived types.
 
-### 1.4.7. Polymorphism (AdditionalAssertions)
+### Polymorphism (AdditionalAssertions)
 
 All mentioned object-oriented programming techniques, namely extension, modification, replacement, and implementation may be used separately or together to implement a polymorphic algorithm and work out a polymorphic program. An example of a polymorphic approach to design a common testing method you may find in the `AdditionalAssertions` static class. From this example, we can learn that our solution requires a polymorphic approach because all users of the `IDrawing.Area` could have different behavior of this method. It is worth stressing that all implementations use the same signature of the method. You may implement polymorphism using abstraction and inheritance. I used abstraction to define the type of the `drawing` argument of the method `AreEqual`, I mean value holder. Abstraction means that we are hiding implementation details. We know that the value referred to by this variable has the `Area` method, and the signature is defined by an interface `IDrawing`. Finally, we are calling a method but we are not aware of its implementation details. At run time when we are talking about concrete values but not language constructs, all implementation must be defined by this method caller, but the implementation could be different depending on the user's needs. The interface is abstract because doesn't provide any implementation details and can be recognized as a contract between the method `AdditionalAssertions.AreEqual` and any user of this method. According to this contract, there are two clear roles. First is the interface user. In this case, it is the AreEqual method in the class `AdditionalAssertions`. The second is the value provider, and in this case, it is all the method callers in spite of whether they are of reference or value types. All of them must refer to concrete types. Hence, to create a value a concrete class must be derived from the contract that is an interface `IDrawing` in this case.
 
-### 1.4.8. Calling Abstract Method (SC)
+### Calling Abstract Method (SC)
 
 Here we can see that the `drawing` argument returns a value, but its type has been declared as an interface offering only the `Area` method. Here, however, we indicate that the object must perform the `Area` operation, but again we should not assume how this operation works. As I said the interface is just a kind of contract. We only specify a formal declaration containing formal arguments because we define only the header of the method called the method signature. As a result, the declaration is there, but it hides (or it rather doesn't provide) implementation details and that is why we call it an abstract declaration. This does not prevent you from using it and calling it, passing to it the current values ​​of its arguments in accordance with the declared signature.
 
-## 1.5. Invisible Types (SC AdditionalAssertions)
+## Invisible Types (SC AdditionalAssertions)
 
-### 1.5.1. Problem description
+### Problem description
 
 This part of the lesson addresses the problem of what to do in case a type definition is not visible in the location where we must refer to this definition. We can observe this issue in the method `AdditionalAssertions.AreEqual`. This method has been declared to allow uniformity of the testing instrumentation. Another typical scenario where we may face up this problem is while working as a team. It allows the team leader to spread the work between team members, and as a result, it could happen that the type is designed by one member and used by other ones. Therefore we must look for solutions allowing us to postpone the definition of the concrete type and avoid any impact on the usage of the type. This scenario I will discuss later together with the discussion on the dependency injection design pattern. Again object-oriented programming concept is well suited to be a foundation for solving this issue.
 
-### 1.5.2. Interface Users Roles
+### Interface Users Roles
 
 Anyway, based on this example we can distinguish two roles, namely value supplier and value user. In this example, the method that is to be involved as a uniform assertion mimics the user role. It is uniform because it is independent of the actual type of the value assigned to the argument named the `drawing` while it is called. All value providers calling this testing method are located in the same testing project. There we have a set of testing methods located in two files. Of course, the type used by the value providers and the type of the called method argument must have something in common. It is the interface `IDrawing`. Based on this definition the value user knows that the value must provide the `Area` method, and the value provider has to assign to this argument only values of a type derived from this interface. This interface may be recognized as an enabler for the value user and a limitation for the data provider. The interface definition we can find using the F12 key - shortcut of the "go to definition" menu entry. The interface is an abstraction that contains only the signature of one method definition. It is used by the called method that mimics the role of the value user. This interface must be inherited and implemented by a set of types we are using to create new values that are to be tested by this method. Because this interface is commonly used by the value provider and the value user is called a contract between them It means that both must agree upon it. Concluding we can develop the `AreEqual` method in advance not waiting for the final definition and visibility of the concrete type of the value in concern. It also allows using this method for testing purposes of an infinite number of types. The only requirement of these types is that all of them must inherit and implement the `IDrawing` interface.

--- a/InformationComputation/PartialDefinitions/README.md
+++ b/InformationComputation/PartialDefinitions/README.md
@@ -1,48 +1,24 @@
-# 1. Partial Definitions
+# Partial Definitions
 
-## Table of content  <!-- omit in toc -->
-
-- [1. Partial Definitions](#1-partial-definitions)
-  - [1.1. Title Page](#11-title-page)
-  - [1.2. What is the problem?](#12-what-is-the-problem)
-    - [1.2.1. Separation of Concerns](#121-separation-of-concerns)
-    - [1.2.2. Merging the Text](#122-merging-the-text)
-    - [1.2.3. An Example of Auto-Generated Code](#123-an-example-of-auto-generated-code)
-    - [1.2.4. Catalog,xsd](#124-catalogxsd)
-    - [1.2.5. Catalog.cs](#125-catalogcs)
-  - [1.3. PersonsDataContext](#13-personsdatacontext)
-  - [1.4. Partial Class and Partial Interface](#14-partial-class-and-partial-interface)
-  - [1.5. PartialClass](#15-partialclass)
-  - [1.6. IPartialInterface](#16-ipartialinterface)
-  - [1.7. PartialsUnitTest](#17-partialsunittest)
-  - [1.8. PartialsUnitTest](#18-partialsunittest)
-  - [1.9. Partial Method](#19-partial-method)
-  - [1.10. PartialClass](#110-partialclass)
-    - [1.10.1. PartialMethodCallTest](#1101-partialmethodcalltest)
-  - [1.11. Homework Part 1](#111-homework-part-1)
-  - [1.12. PartialClass](#112-partialclass)
-  - [1.13. Homework part 2](#113-homework-part-2)
-  - [1.14. Thanks for your time](#114-thanks-for-your-time)
-
-## 1.1. Title Page
+## Title Page
 
 In this lesson, we continue the discussion of topics related to the representation of information as data processed by a computer.  We know that a basic term relevant for this discussion is type notion. The type could be defined explicitly by the developer. During the previous lesson, we talked about how the programming language supports us in data harmonization, where the variable type is inferred from the value type assigned when the variable is declared. It means implicit type declaration. It requires a special syntax of the text representing the assigned value. Using this approach the explicit type definition doesn't exist so we can't even specify a name for this type. Hence, we call this kind of type anonymous type. It is permanently assigned to the variable in which it was defined. A drawback of this approach is the impossibility to define custom behavior. Hence we are limited to using only operations associated with the anonymous type by the programming language definition.
 
 During this lesson, I will pay special attention to issues related to the auto-generated data types creation based on the definitions of the external types. This time we will enter the domain of type conversion. To make the discussion generic I will skip details related to the conversion process itself. I will only try to rise up issues relevant to the design process and allow us to be prepared for the consequences of the conversion. Let me stress that in spite that a type is auto-generated the developer has full responsibility for the final processing results robustness. For this approach, we assume that the external data type is available in some form and you have to convert it using some programming tool to get the equivalent type in the programming language. This may sound puzzling, but I want to reassure you that we will only focus on the conversion engineering itself but not on mapping external types to internal data types.
 
-## 1.2. What is the problem?
+## What is the problem?
 
 Converting some external type defined in any form to a type definition expressed using a programming language, using any programming language, always produces text. Let me remind you that at the beginning the program is just a text that complies with the syntax and semantics of the selected programming language. Therefore, we enter the issues of text management, i.e. writing, modifying, and mixing text in various circumstances. We will be talking about text management engineering in the context of the type definition.
 
 To be honest I must state that the linguistic constructs in question have a much wider application than just facilitating the conversion of types. In other words, types conversion is only an example of the applicability of the partial types and methods that allows a systematic discussion on this approach.
 
-### 1.2.1. Separation of Concerns
+### Separation of Concerns
 
 When working on the text of the program, we may encounter a need to separate selected parts of a definition to improve efficiency by spreading the development of the parts to different members of a team. It allows leveraging the separation of concern concept if, for example, the text is too long or contains separate subjects or logical threads. In such a situation, extracting a piece of text into separate text files is one of the options that comes first, as the most obvious.  It also allows for avoiding conflicts while the text is maintained in a remote repository. The problem is that a file is also a compilation unit for most development environments, so it must contain correct text in the context of the syntax and semantic rules of the programming language.
 
 However, it must be remembered that an alternative to dividing the text into fragments is also possible after engaging the object-oriented programming and the use of the inheritance paradigm, thanks to which we can also meet this goal, i.e. divide the selected text into logical fragments. Both approaches have advantages and disadvantages therefore they are applicable depending on the conditions.
 
-### 1.2.2. Merging the Text
+### Merging the Text
 
 In addition to splitting development, sometimes we may encounter another need to merge modifications of program text that come from different sources. A typical example is auto-generated program text by a tool. It also could cause that conflicts will occur, namely simultaneous text modification in the same place by different sources.
 
@@ -53,37 +29,37 @@ We must also consider a scenario where we have to use different programming lang
 
 Anyway, if the compiler must be engaged in the code merge it could be supported by the dedicated syntax and semantics of the programming language definition.
 
-### 1.2.3. An Example of Auto-Generated Code
+### An Example of Auto-Generated Code
 
 In further consideration, we will skip the issues of teamwork, or rather the consequences of teamwork, because here the solutions are already known and are not related to the syntax and semantics of the language. Instead, let's look at some examples related to type conversion by a tool and multi-language programming.
 
-### 1.2.4. Catalog,xsd
+### Catalog,xsd
 
 The first translation illustrating the problem of automatic code generation can be found in the project where examples for the next block of topics are located, namely for streaming data. It is an XSD file containing an XML schema document. Here it is already open. This file describes sample types in XML. So, in a language that is completely C# independent. These definitions, therefore, cannot be used directly in the program, because the XML notation has inconsistent syntax. As mentioned before, one way to solve this problem is to generate types or an equivalent type based on them, which will be written according to the rules of the selected language. And here we have another file, this time with the `cs` extension, a file which syntax and semantics are consistent with the selected language, and which has been automatically generated. This is evidenced by the inscriptions in the header of this file. This file is located in the same project as the file associated with the XSD file. To generate this file, I wrote a script that we can see on the screen now, using the XSD program. This program converts the file `Catalog, xsd` to a CSharp file with the same name but with a different extension. The type definitions are placed in the namespace that is defined here. To run this script and generate the file, you need the operating system command interpreter window that has been launched using the Visual Studio environment, and therefore which has initialized all system variables that allow the use of the tools of the Visual Studio environment. Let's see how this script will work now. Well, let's go back to the program that was previously generated and make any changes to that program. The most spectacular modification is, of course, the deletion of the whole content. Let's remember the changes. So the file is empty at the moment. And of course, if we run the script, the script ends after a while and Visual Studio asks me if I want to read the new content. I have agreed to this and we can see that again we have the content I did delete previously. This yellow line on the left indicates changes from the previous version. Since I saved an empty file previously, everything has been changed. It is possible that the previous content has been restored if the XSD file has not changed.
 
 This example illustrates a problem, namely, if I make any changes in this text, of course, they will not be effective, i.e. any changes will be overwritten when the file is regenerated. The warning is written here in the header that any changes will not be effective after regenerating this file, i.e. after restarting the script.
 
-### 1.2.5. Catalog.cs
+### Catalog.cs
 
 A similar example can be found in a project related to the topic of structured data. This file is also auto-generated not from the types that are defined in XML, but from the database schema. We will not discuss how to generate it now. We will come back to it when we discuss external data management in a separate course.
 
-## 1.3. PersonsDataContext
+## PersonsDataContext
 
 An example that illustrates the use of different programming languages can be found in the Graphical Data project. Here we have a file called `MainWindow`. It is written using the XAML. This language is based on XML. The important thing for us is that this file together with another file creates one class, and finally one type definition. Since it uses a different language, the text of the definition parts cannot be merged in one file. In this case, the type definition must be split into two files.
 
-## 1.4. Partial Class and Partial Interface
+## Partial Class and Partial Interface
 
 In this situation, as we have just talked about, the concept of the partial definition could be found very useful. Let's start with partial class and partial interface.
 
-## 1.5. PartialClass
+## PartialClass Part 1
 
 Examples of a partial class are in the `Partials` folder. Here we have two files that have the extensions `p1` and `p2`, respectively, to mark them as part one and part two. They contain the definition of the same class. In other words, this definition is divided into two parts that form one definition - one whole. One part is located in the first file and the other one is in the second file. Of course, including the word `partial` also allows the class definition to be split but located in the same file. Here is an example of the third part of this class placed in the same file as part two. Let me emphasize that this possibility is only a side effect of a language definition in which the partial definition concept is not related to the files. This scenario will not work for auto-generated types, as the whole content will be overwritten during regeneration. This does not exclude the possibility that there are some scenarios in which splitting the definition into several parts placed in the same file makes some substantive sense. A typical example would be the use of a separation of concerns principle. As a result, you may consider breaking the definition of the same type into two logically coherent fragments and placing them in the same file. Remember, however, that instead, we can use inheritance, which additionally emphasizes the hierarchical dependency relationship between parts.
 
-## 1.6. IPartialInterface
+## IPartialInterface
 
 Similarly, we can apply this concept of partial definitions to interfaces. Again in the folder `Partials`, there are two files `p1` and `p2`, which contain two parts of the same definition of an interface that was used to define the previously discussed class.
 
-## 1.7. PartialsUnitTest
+## PartialsUnitTest Part 1
 
 Let us analyze the behavior of partial definitions with the use of unit tests. Here we have a unit test that was prepared for this very analysis. As we can see, in the first unit test we create an object of the class `PartialClass`. From the point of view of use, this class behaves like one definition, although partially defined in several parts.
 
@@ -91,21 +67,21 @@ For several parts to behave as one class, all parts must have the same name, so 
 
 One significant consequence of this fact is that the source code in each part must be available to the compiler while the build process is running. This means that all files must be in the same project; in the same compilation unit.
 
-## 1.8. PartialsUnitTest
+## PartialsUnitTest Part 2
 
 Let's go back to unit testing again. We use two instance methods of a partial class in this unit text. ALt F12 will lead us to the definition of the former. This method is defined in part one. And the other method - I'll use ALT F12 again to find it - is defined in part two. So they were placed in the same definition and are available in the same object that was created from the common definition. The definition itself, on the other hand, is a composition of fragments.
 
 We already know that a common definition is created by merging text from partial definitions. However, it is worth knowing here what are the rules of this text merging. The first rule is that the text is merged so as not to cause conflicts we know from using repositories to manage text for teamwork. Leaving aside the details of the compilation process, we can only remember that this operation uses language syntax rules. In other words, the text is mixed in the context of the syntax rules of the language. As a result, it is possible to avoid conflicts in the text of the program instead of bothering with them. However, conflicts must not be confused with errors in the content of the program. These, after all, can occur even if the definition is not made up of parts. To make it clear, we can distinguish here three parts of the class header that are relevant to this process. The first part is the attributes that come before the class header. Any modifiers that appear before the partial keyword. And the inheritance chain that follows the class name and the colon. And here these parts will be merged in such a way as to create a common header from partial headers based on the syntax of the programming language. So, first, all kinds of modifiers cannot contradict each other. They can be repeated or omitted, but not contradictory. For example, one part of a class definition cannot be public, and the other part, for example, private. Also, the inheritance chain must be consistent. All the identifiers that are in the inheritance list will be common to all parts when they are merged together. Let's go back to the previous definition, so let's withdraw this modification to make the definition correct.
 
-## 1.9. Partial Method
+## Partial Method
 
 Now let's move on to the partial method definition, which is an integral part of the partial class definition.
 
-## 1.10. PartialClass
+## PartialClass Part 2
 
 From the sample code, we can see that the partial method also uses the keyword partial. But the other feature of the partial method is that no block has been defined for that method. We call it not defined because a block in the partial method is not required. So it's a bit like declaring an abstract method as a member of an interface.  For example here where we do not have the word `partial`, but we also do not have a block that defines the functionality of the method. So this method is not fully defined. The difference between a declaration that is an abstract definition, as in the case of interfaces, and a method for which only the header is defined as a partial declaration, in a partial class is that in the case of an abstract method it must be implemented in order to be used. So we cannot create an instance of a class for which even one abstract method has not been implemented. This is the basic rule of object-oriented programming, in which all definition members must be unambiguously defined. The situation is different in the case of partial classes. In this case, the `PartialMethod` does not need to be implemented. I put it here in the second part of the definition of this method where it is implemented, but let's investigate the behavior of this partial method using unit tests.
 
-### 1.10.1. PartialMethodCallTest
+### PartialMethodCallTest
 
 There is a method in unit tests that is responsible to test a partial method call. Here we create an instance of the class in concern and then call the partial method. Please note that it is an indirect call. Again, ALT F12 will show that this partial method is called indirectly using an additional method that I put in the definition of this class. The question is why. Try to guess but I will answer this question shortly.
 
@@ -117,18 +93,18 @@ If a partial method is not implemented all calls of this method are removed from
 
 Now let's return to the question of why I am calling this method indirectly. Well, I call it indirectly because all partial methods must be private. We can only access them from within this partial class definition, actually from any part of this definition, because the code is merged before compilation, we don't have access from the outside. The reason is that during the merging of the source code the compiler has to remove the call to a method if it is not implemented. To delete partial definitions in a text blend, it must have this call available locally. This would be impossible if the call were placed outside the definition. This can be guaranteed if we use the encapsulation paradigm and the declaration is private. So the compiler's activity would now have to be extended to other parts of the program, not just the partial definition.
 
-## 1.11. Homework Part 1
+## Homework Part 1
 
 As usual, let's go on to homework definition. Well, as part of your homework I am asking you to expand the source code that we see here with a unit test that will confirm that the class definition will contain all the attributes regardless of which part of the class definition is preceded by the attribute.
 
-## 1.12. PartialClass
+## PartialClass Part 3
 
 Maybe a few words of explanation about the homework. Here we have two definitions. Precisely, one definition in two parts of a partial class. The first part is shown at the top and this part contains the attribute. There is also an attribute decorating the second part but commented. Let me delete the comment to add this attribute to the definition. Unit tests check the number of attributes for the selected class. As a result of the test, we can show that the appearance of another attribute, before the next part of the attribute, caused the number of attributes to be not equal to one, but two. Anyway, we can examine the results of this test here. This method checks if the length of the array is equal to the number really the array length is 2. This is not surprising because the text has been merged, as I said before, and the attributes that are in front of all the parts will appear before the common definition created by the compiler. The same should be done when solving the homework, but this time additionally the task is to check which attributes are present before the common class definition.
 
-## 1.13. Homework part 2
+## Homework Part 2
 
 And two more questions. Will the test result depend on where the attributes were added? And; why a partial method cannot return a result and have out parameters?
 
-## 1.14. Thanks for your time
+## Thanks for your time
 
 And that's all about partial definitions, which, as it turns out later, will be very useful for defining types for external data. We will come back to this language construct many times. Thanks for your attention and see you next lesson.

--- a/InformationComputation/README.md
+++ b/InformationComputation/README.md
@@ -1,53 +1,6 @@
-# 1. Computation of Information
+# Computation of Information
 
-## Table of content <!-- omit in toc -->
-
-- [1. Computation of Information](#1-computation-of-information)
-  - [1.1. Executive Summary](#11-executive-summary)
-    - [1.1.1. Welcome](#111-welcome)
-    - [1.1.2. Instructor Intro](#112-instructor-intro)
-    - [1.1.3. What's the problem?](#113-whats-the-problem)
-      - [1.1.3.1. Introduction](#1131-introduction)
-      - [1.1.3.2. Programming in Practice](#1132-programming-in-practice)
-      - [1.1.3.3. Computer Science](#1133-computer-science)
-      - [1.1.3.4. Information Processing Applicability Scope](#1134-information-processing-applicability-scope)
-      - [1.1.3.5. Information as a knowledge](#1135-information-as-a-knowledge)
-      - [1.1.3.6. Information Processing Summary](#1136-information-processing-summary)
-      - [1.1.3.7. Contradiction](#1137-contradiction)
-    - [1.1.4. Outline of Scope](#114-outline-of-scope)
-    - [1.1.5. Education context](#115-education-context)
-      - [1.1.5.1. Language](#1151-language)
-      - [1.1.5.2. Development Environment](#1152-development-environment)
-      - [1.1.5.3. GitHub](#1153-github)
-      - [1.1.5.4. Working as a Team](#1154-working-as-a-team)
-      - [1.1.5.5. How to Use Supporting Entities](#1155-how-to-use-supporting-entities)
-    - [1.1.6. Audience](#116-audience)
-    - [1.1.7. Learning outcomes and benefits](#117-learning-outcomes-and-benefits)
-  - [1.2. Information Representation](#12-information-representation)
-    - [1.2.1. Preface](#121-preface)
-    - [1.2.2. What's the problem?](#122-whats-the-problem)
-    - [1.2.3. Introduction to Title Explanation](#123-introduction-to-title-explanation)
-    - [1.2.4. First Problem](#124-first-problem)
-    - [1.2.5. First Conclusion](#125-first-conclusion)
-    - [1.2.6. Fundamental Inconsistency](#126-fundamental-inconsistency)
-    - [1.2.7. Syntax Analysis](#127-syntax-analysis)
-    - [1.2.8. Semantics analysis](#128-semantics-analysis)
-    - [1.2.9. Data Definition](#129-data-definition)
-    - [1.2.10. Coding System](#1210-coding-system)
-    - [1.2.11. Possibility to Replace Information Term by Data](#1211-possibility-to-replace-information-term-by-data)
-    - [1.2.12. Algorithm Implementation](#1212-algorithm-implementation)
-  - [1.3. Algorithm Versus Program](#13-algorithm-versus-program)
-    - [1.3.1. Preface](#131-preface)
-    - [1.3.2. What's the problem?](#132-whats-the-problem)
-    - [1.3.3. Algorithm implementation](#133-algorithm-implementation)
-    - [1.3.4. Computer Program is Text](#134-computer-program-is-text)
-    - [1.3.5. Programming Language](#135-programming-language)
-    - [1.3.6. Binary machine needs binary alphabet](#136-binary-machine-needs-binary-alphabet)
-    - [1.3.7. Aim of the course](#137-aim-of-the-course)
-  - [1.4. Conclusion](#14-conclusion)
-  - [1.5. See also](#15-see-also)
-
-## 1.1. Executive Summary
+## Executive Summary
 
 Information Computation means a process engaging a computer (a physical device) to process information as a series of actions or steps taken in order to achieve a particular result or help to fulfill a task. The main challenge is that information is abstract, it is a kind of knowledge that cannot be processed directly by any physical device.
 
@@ -55,7 +8,7 @@ This MS Visual Studio (TM) solution contains code that by design is to be used a
 
 Generally speaking, two main topics are covered. That is dealing with the data recognized as the information representation and behavior description using a program compliant with an algorithm.
 
-### 1.1.1. Welcome
+### Welcome
 
 I would like to invite you to participate in a course on information processing. The course is a part of the Programming in Practice series of courses. My point is that we could distinguish between two kinds of education:
 
@@ -64,73 +17,73 @@ I would like to invite you to participate in a course on information processing.
 
 This curse will focus on p. 2 - the improvement of your knowledge related to software engineering. My goal is that it will be beneficial for you in the long run.
 
-### 1.1.2. Instructor Intro
+### Instructor Intro
 
 My name is Mariusz Postół. If your job or professional career depends on software development skills, consider joining us to learn how to improve your knowledge and experience in this respect. I'm gonna share with you the principles of a learning concept called Programming in Practice - information Computation. It has evolved atop 30 years of experience gathered by me as a University teacher and leader of hundreds of innovative IT projects realized, among others, for aviation, energy, tobacco, and mines industries. I am also an author and project leader of commercial software packages published on GitHub as open-source software. Since 1994 - that is from the very beginning - I am also a lecturer at Lodz University of Technology. If you are serious about programming skills, I believe that this mixture will cause a synergy effect. Welcome and thank you for joining the community.
 
-### 1.1.3. What's the problem?
+### What's the problem?
 
-#### 1.1.3.1. Introduction
+#### Introduction
 
 All subsections in this course begin by trying to define the most important topics. And now let's try to answer the question of what the problem is, but in the context of the entire course - as an introduction to the course as one whole. Let's start by investigating the meaning of the title keywords.
 
-#### 1.1.3.2. Programming in Practice
+#### Programming in Practice
 
 To learn more about programming in practice meaning check out the free introduction to the series of courses titled [Programming in Practice - Executive summary][2108-PiP-TP-repository]. It is a free course published on [udemy.com][MPUdemy]. Consider enrolling in. Let us try to start our research by answering a very fundamental question what is computer science, the main field of our activity I mean software engineering.
 
-#### 1.1.3.3. Computer Science
+#### Computer Science
 
 > **Computer Science**: is the study of computers and computational systems. Computer scientists deal mostly with software and software systems; this includes their theory, design, development, and application.
 
 This definition says that Computer Science is the study of computers and computational systems. Computer scientists deal mainly with software and software systems; this includes their theory, design, development, and application. In general, we can conclude that it is dedicated to information processing - it deals with information processing and the production of systems used to process information. Unfortunately, I have a couple of problems with this definition.
 
-#### 1.1.3.4. Information Processing Applicability Scope
+#### Information Processing Applicability Scope
 
 The first problem I have is the meaning of the term information processing itself. For example, are medicine or journalism not concerned with information processing? They also use technology. Here we need to make a certain distinction between what doctors and journalists do and our activities as software developers. This question is the easiest to answer because we can say that computer science deals with the automation of the information processing process. Thanks to this, we can say that computer science is a service field that allows us to provide solutions, i.e. information processing systems that will be used in medicine, for example for diagnostics or in journalism for the publication of a new edition of a newspaper. Concluding in our activity we should pay special attention to producing software that guarantees the repeatability of outcomes
 
-#### 1.1.3.5. Information as a knowledge
+#### Information as a knowledge
 
 In this context, the information term should be understood as knowledge about the state and behavior of the process in concern. The process that we want to monitor or control, with the use of devices, with the use of technology, with the use of computers to be precise - to achieve the goal automatically.
 
-#### 1.1.3.6. Information Processing Summary
+#### Information Processing Summary
 
 Explaining the title of our course, we came to the conclusion that the discussion concerns the automation of information processing. This process is based on two tightly coupled terms. The first relevant term is **information** about a process - shortly called process information. The process information must be recognized as knowledge about the state and behavior of the process. The second term is the **algorithm**, which again is information but this time about how to solve the problem in concern. In other words, we can say that processing must be implemented based on a knowledge of how to achieve a goal, or how to solve a given problem by applying information processing. That is algorithm could be recognized as an abstract description of the information processing behavior.
 
-#### 1.1.3.7. Contradiction
+#### Contradiction
 
 Concluding, the automation of information processing requires the use of technology, and therefore a computer. A computer is a device that is governed by the laws of physics. And here we come to a fundamental contradiction, namely, during this course, we need to answer the question of how a physical machine can process something that is abstract, namely information. The problem addressed by this course is how to represent process information and implement algorithms to be suitable for computation that is processing using a computer device.
 
-### 1.1.4. Outline of Scope
+### Outline of Scope
 
 Referring to the previous discussion, the automation of information processing requires the use of technology, and therefore a computer. A computer is a device that is governed by the laws of physics. And here we come to a fundamental contradiction, namely, we need to answer the question of how a physical machine can process something that is abstract, namely information. In this section, we will continue a more or less theoretical discussion necessary to make a foundation for further learning related to information representation as a consistent part of programming language. After that, the next subsection titled `Information representation` is focused on how to represent process information. It covers the fundamentals of types in the context of object-oriented programming. We will also learn some special approaches to types definitions, namely anonymous, partial, and generic types. Last but not least section titled `Algorithm Versus Program` covers selected aspects of algorithm implementation using the object-oriented programing concept and layered program architecture. The main goal is to deal with software engineering fundamentals. Concluding, the main goal is to understand the applicability scope - reasons why we need all that special and more or less dedicated solutions and principles of the program architecture.
 
-### 1.1.5. Education context
+### Education context
 
-#### 1.1.5.1. Language
+#### Language
 
 As a general goal of the course, we will focus on learning rules but not training in a particular language or development tool. To make sure that our discussion is practical and implementable we must use a selected programming language as a context for further explanation. I have selected CSharp to prepare examples that are to be explored during deploying the Information Computation course. But let me get ahead of your doubts and stress now that in principle the programming language is considered only a tool to write down examples. According to the main assumption of the course, I hope it will be not an obstacle to port solutions to another development environment dominated by other programming languages.
 
-#### 1.1.5.2. Development Environment
+#### Development Environment
 
 Again, to make our discussion about programming practical we must distinguish between design-time and run-time environments. Both are tightly coupled but the possibility to trace the behavior of the examples at run time is very important for the `Programming in Practice` as a learning path and also for the `Information Computation` course. I selected Visual Studio as the integrated development environment to be used to deal with examples in the course.
 
-#### 1.1.5.3. GitHub
+#### GitHub
 
 All topics covered by the course are discussed in the context of examples stored in a public repository. I have selected GitHub to store the code examples. Additionally, GitHub is a perfect solution because it allows improvement or adding new examples. All examples used during the course are gathered in the TP public open-source repository.
 
-#### 1.1.5.4. Working as a Team
+#### Working as a Team
 
 Today almost always software is developed by teams. That is tightly coupled contributors. Hence you have to be prepared to work as a team member. We cannot organize real teamwork, so I propose to apply community collaboration by employing the GitHub repository. The  GitHub repository is not only the storage of reusable open-source software but is also a collaboration platform. When contributing to this repository, please first discuss the change you wish to make via issue, email, or any other method with the owners of this repository before making a change. Visit the repository to follow the contribution rules in all your interactions with the repository.
 
-#### 1.1.5.5. How to Use Supporting Entities
+#### How to Use Supporting Entities
 
 Discussing details on how it works and how to use the mentioned above tools is a good subject for a few independent courses. However, at least we must know how to get started. Enroll in and finish the free course titled [Programming in Practice - Executive Summary][2108-PiP-TP-repository] to get more on how to use the CSharp language, Visual Studio, and GitHub repository. Check it out also if you need more information about the Programming in Practice general educational path this course is compliant with.
 
-### 1.1.6. Audience
+### Audience
 
 To begin with, let's start by defining the target group. The course is intended for students and teachers who have knowledge and experience related to programming fundamentals. It is not a hard requirement, but rather a recommendation, but it is advisable to already have some knowledge and experience in object-oriented programming. Certainly, it will be useful to recall such concepts as instruction, method, type, class, interface, reference, iteration, recursion, polymorphism, inheritance, abstraction, encapsulation,  etc. Although the goal of the course is not to learn the selected programming language or the development environment, the knowledge of CSharp, the MS Visual Studio environment, and the GitHub repository, which are used to present sample programs, will be very helpful. Enroll in and finish the free course [Programming in Practice - Executive Summary][2108-PiP-TP-repository] to accommodate this requirement. Usually, background knowledge is enough to finish successfully this course and reuse the knowledge and experience you will get.
 
-### 1.1.7. Learning outcomes and benefits
+### Learning outcomes and benefits
 
 In the context of examples, you will learn how to use types to represent custom information and how to organize the program text compliant with the layered architecture. After the course, you will be familiar with a vast variety of methods that can be applied to design the object model as a subject for further information computation. You will also be able to
 
@@ -140,81 +93,82 @@ In the context of examples, you will learn how to use types to represent custom 
 
 All discussion is conducted based on the examples gathered in a dedicated solution and maintained using a GitHub repository. These examples are ready to use as a foundation for programming skills learning. All the time I will keep the discussion on a level that guarantees common and easy portable conclusions, which are applicable independently of the used development environment.
 
-## 1.2. Information Representation
+## Information Representation
 
-### 1.2.1. Preface
+### Preface
 
 The main goal of this subsection is to explain the meaning of the course title to create a starting point to improve your further understanding.
 
-### 1.2.2. What's the problem?
+### What's the problem?
 
 To explain the meaning of the course title we must start by explaining the meaning of the keywords that are in the title of this course. So, the terms: information, and computation require clarification. The research must be conducted in the context of computer science and information technology. Of course, don't expect deep dive or a theoretical lecture because in general, I am going to present a part of the programming in practice story. Let me stress again that my goal is an improvement of your development skills but not a formal elaboration and definition of the meaning of the course title - in other words - I will try to avoid a complicated discussion related to the meaning of the title.
 
-### 1.2.3. Introduction to Title Explanation
+### Introduction to Title Explanation
 
 Thanks to googling, it is easy to discover from the internet something like this "computer science uses technology to solve problems and prepare for the future". We can conclude from this statement that a computer may be recognized as a technology used to process information provided that information is knowledge about problems and the future. It looks like a common junction point with the information technology subject. In other words, we are talking about applying a technique and technology to problem-solving, or information processing to be more general. I must say that I have a few problems with this approach or rather this explanation.
 
-### 1.2.4. First Problem
+### First Problem
 
 The first problem I have is the term information processing itself. Let me ask you a question, do you think that medicine or journalism is not concerned with information processing? It is an important question for further discussion because we need to make a certain distinction between what doctors and journalists do and what you are going to do as an active member of the computer science ecosystem. Additionally, let me stress that doctors and journalists also use technology on a daily basis. This question is the easiest one to answer because we can say that computer science deals with the automation of information processing by applying programmable devices, I mean computers. Thanks to this, we can say that computer science embeds also an engineering domain aimed at providing solutions - information processing systems to be used in medicine for diagnostics or in journalism for the publication of a newspaper.
 
-### 1.2.5. First Conclusion
+### First Conclusion
 
 Concluding, our particular goal is to learn how to make information processing automatic using computers. In this context, information should be recognized as knowledge about the state or behavior of a set of interoperable real-time activities. The activities that we want to monitor or control, with the use of technology, or more precisely with the use of physical programmable devices, so as to achieve problem-solving automatically. It is our goal and responsibility as computer science active members of an ecosystem  - shortly developers.
 
-### 1.2.6. Fundamental Inconsistency
+### Fundamental Inconsistency
 
 The automation of information computation requires the use of technology, simplifying a computer. Any computer is a device, so it is governed by the laws of physics. And here we come to our fundamental inconsistency, how it is possible to use a physical device (the computer) to operate against abstraction (information). To solve the problem, I mean to resolve this inconsistency, let's try to address this issue by answering another question, namely, whether the left side is equal to the right side.
 
 ![InformacjaVersusData](.Media/2109-010201007000-InformationVersusData-InformacjaVersusData.png)
 
-### 1.2.7. Syntax Analysis
+### Syntax Analysis
 
 The first answer may be based on the observation that what we see are characters. That is on the left side of the equal sign we have two characters, and on the right side of the equal sign, we have one character. From this fact, we can conclude, that the left side is not equal to the right side. Generally speaking, we use characters in the syntax layer analysis. In this discussion, the set of allowed characters that we can use, I mean concatenate to make a valid string is called an alphabet. If the alphabet is intended for a human, it contains alphanumeric characters - for example letters, digits, or symbols for the Latin alphabet. In the case of today's computers, which are governed by the laws of physics, we must consider only two discrete states. It makes a difference because in this case, the alphabet must contain exactly two signs. Following this rule, the alphabet is called a binary alphabet - no matter what signs it contains. In case the alphabet is intended for a human we are talking about characters, in case the alphabet is intended to be used by a computer we are talking about signs. In both cases, we are talking about the alphabet as a set of entities to be concatenated in streams. For the characters, we have a shape, in the case of signs we have measurable features.
 
-### 1.2.8. Semantics analysis
+### Semantics analysis
 
 If we now move from a syntax analysis to a semantic analysis of what we see, we can claim that the left side may represent the number four. And the right side can also represent the number four. In that case, the numbers are equal to each other, so the equal sign is legitimate because both sides are equivalent. That could have the same meaning. Only one question remains to be answered: what conditions must be met for the left side to represent the number four, and the right side also represents the number four? In this case, we are comparing the meaning but not the streams of characters. Again, meaning is an abstraction so physical computers cannot be able to compare meanings, they always compare bitstreams, and they always work on a stream of signs.
 
-### 1.2.9. Data Definition
+### Data Definition
 
 Continuing this discussion to resolve any doubts related to the meaning of the title, I will use a funny illustration in which the number four is presented as a ghost, something that does not exist in the real world. It is information, it is an abstraction, but it has two equivalent representations interconnected by arrows indicating a bidirectional relationship with the streams of characters associating a meaning to them. To stress the difference between information and information representation that is associated with streams of characters the representation we call data. I believe that now it is very easy for you to distinguish the terms information and data. The simplified rule is as follows: if something is a stream of signs and we are able to assign a meaning to this stream it is just data.
 
 ![Coding System](.Media/2109-010201010000-InformationVersusData-InformacjaVersusData.png)
 
-### 1.2.10. Coding System
+### Coding System
 
 To build a meaningful relationship between something abstract, in our case a number, and something that has a physical nature - a sequence of characters - we first need to define the alphabet, I mean a set of characters that you are allowed to use in this sequence. Then we need to define a set of rules expressing how to concatenate these characters into valid sequences - called syntax. Finally, we must define the semantics, I mean rules we could apply to correct characters sequences to associate meaning to them. Finally, the alphabet, syntax, and semantics make up a coding system. It is a very important conclusion for subjects related to types, which I will cover.
 
-### 1.2.11. Possibility to Replace Information Term by Data
+### Possibility to Replace Information Term by Data
 
 Returning once again to the discussion about the title of the course, we can observe that in reality, we are computing the data but not the information. Hence, someone could put forward a proposal that maybe it is enough to replace the term information with the term data, and as a result, we will be able to avoid this whole long introduction, which is relatively low-level and theoretical. Of course, the answer is that we can't do that because your duty, as a software developer, is to select or even create if necessary an appropriate coding system. The good news is that the creation of a new coding system is built upon the existing ones. In other words, typically new coding systems are derived from the existing ones. In any case, it is part of your responsibility, so you must know how to deal with it and acquire appropriate skills.
 
-### 1.2.12. Algorithm Implementation
+### Algorithm Implementation
 
 Explaining the title of our course, we concluded that we are talking about the automation of the information computation process. To be more practical and talk in the context of problem-solving we may recognize the information as a piece of knowledge about the state and behavior of a selected real-time set of activities - part of the natural realm. But to solve any problem using a computer we need to know how to compute the information to fulfill an expectation of the activities owner or a manager. Again, additionally, we need knowledge, a piece of information on how to solve the selected problem. How to monitor and possibly control the behavior of the activities in concern. How to control the activities to achieve the chosen goal. This kind of knowledge we may call an algorithm. Let me stress it is also information that cannot be directly applied or used by any physical device including but not limited to computers.
 
-## 1.3. Algorithm Versus Program
+## Algorithm Versus Program
 
-### 1.3.1. Preface
+### Preface
 
 Let me recall that our challenge is to learn all about information computation. Information computation means a process employing a computer (a physical device) to process information as a series of actions or steps taken to achieve a particular result or help fulfill a task. The first challenge of this process is that information is abstract. In other words, it is a kind of knowledge that cannot be used directly to describe computer behavior. In this subsection, we will learn how to describe the actions or steps to achieve a particular result in compliance with the limitations of modern computers. I mean the computer is a physical device and cannot process any abstraction.
 
-### 1.3.2. What's the problem?
+### What's the problem?
 
 - how to control a physical device (precisely computer) behavior to process information in compliance with an algorithm
 
 Explaining the title of the course, we concluded that we are talking about the automation of information processing. To be more practical and talk in the context of problem-solving we may recognize the information as a piece of knowledge about the state and behavior of a selected real-time set of activities - part of the natural realm. But to solve any problem using a computer we also need to know how to process the information to reach a goal. Again, additionally, we need information, a piece of knowledge describing how to solve the selected problem. How to control the activities to achieve the goal we are facing with. This kind of knowledge we call an algorithm. Let me stress it is also information that cannot be directly applied or used by any physical device including but not limited to computers. The main challenge of this subsection is to learn more about how to do it.
 
-### 1.3.3. Algorithm implementation
+### Algorithm implementation
 
 Computation means a set of actions that ensure the automation of information processing. To ensure automatic processing, we need to use technology, which means a programmable device. Today it is the binary computer for sure. Anyway, we must ensure that this processing engine behaves following an appropriate algorithm. The algorithm is again information because it is a piece of knowledge on how to solve the problem. Hence, it is an abstraction that will be useful in the computation process only if it can be represented in binary form - similar to the process information discussed earlier. And this is the next task of software developers, namely algorithms implementation, and the results of this work are computer programs. That is a recipe instructing the computer how to control the activities to achieve the chosen goal. From the previous subsection, we learned that information to be processed by a physical device must be represented by data first using the alphabet, syntax, and data semantics. That is a coding system. A similar approach can be applied to the algorithm, which is also a piece of information describing the computer behavior - shortly algorithm. The most promising solution is coupling together custom coding system design and algorithm implementation because both are tightly coupled.
 
-### 1.3.4. Computer Program is Text
+### Computer Program is Text
 
 Today, we do not need to implement the algorithm using a binary representation. Thanks to the compilation process, we can use alpha-numeric alphabets - just like the natural languages we use on a daily basis. Typically the alphabet is derived from the Latin alphabet. This leads to the statement that any program at the beginning of its life cycle is just a text, hence a sequence of characters. **Text becomes a computer program when it meets additional rules that will enable it to be compiled.
 **
-### 1.3.5. Programming Language
+
+### Programming Language
 
 And so we come to the term programming language. To be used to control a computer it is a kind of contract between the software developer and compiler that both must comply with and use to finally implement information processing as the data computation. It must be a set of rules. The contract must be exhaustive. To fulfill this requirement the syntax and semantics must be defined and applied respectively to provide appropriate rules that can be used:
 
@@ -223,15 +177,15 @@ And so we come to the term programming language. To be used to control a compute
 
 CSharp is such a language that I use to explain software development issues with concrete examples.
 
-### 1.3.6. Binary machine needs binary alphabet
+### Binary machine needs binary alphabet
 
 Using an alphanumeric instead of a binary alphabet and the requirement that the design of the process data coding system should be coupled together with the algorithm implementation leads to a need to replace the coding system with the type concept to design the information representation and computer behavior. Defining a programming language atop of alphanumeric alphabet allows us to better suit the definition to human needs finally we get high-level languages. The type concept is the main subject of the section titled `Information representation`.
 
-### 1.3.7. Aim of the course
+### Aim of the course
 
 This way we finished the theoretical introduction. Maybe it was boring or annoying for you but I believe that it will give you a firm foundation to reach the main aim of the course. It must be stressed that the aim of the course is to deal with the implementation of selected algorithms, not just training that is scoped on the language itself and the development environment in which it is embedded. In order to ensure the practical nature of the course, selected topics are only illustrated using CSharp and the Microsoft Visual Studio development environment. A foundation of the course is that the main goals, design patterns, and discussed scenarios are of generic nature to be easily portable to other environments. The selected language and tools are only used to conduct the discussion using a well-defined environment and ensure that the course achievements are also very practical.
 
-## 1.4. Conclusion
+## Conclusion
 
 It is time to conclude our discussion and idea exchange related to Information Computation.
 
@@ -256,7 +210,7 @@ The second part titled `Algorithm Implementation` covers the following examples 
 - Inter Layers Communication
 - Dependency injection
 
-## 1.5. See also
+## See also
 
 - [Mariusz Postol profile on udemy][MPUdemy]
 - [Mariusz Postol profile on GitHub][MPGitHub]


### PR DESCRIPTION
Added .markdownlint.json file with initial configuration.

Removed table of contents and updated headings in following solutions:
- ConcurrentProgramming\README.md
- InformationComputation\README.md
- InformationComputation\DependencyInjection\README.md
- InformationComputation\GenericClassesMethods\README.md
- InformationComputation\LayeredArchitecture\README.md
- InformationComputation\LayersCommunication\README.md
- InformationComputation\ObjectOrientedProgramming\README.md
- InformationComputation\PartialDefinitions\README.md

Contributes #318