### PR TITLE
Fix flaky LambdaSyntaxTest

### DIFF
--- a/ExDataManagement/FunctionalProgramming/FunctionalProgramming.UnitTest/AnonymousFunctionsUnitTest.cs
+++ b/ExDataManagement/FunctionalProgramming/FunctionalProgramming.UnitTest/AnonymousFunctionsUnitTest.cs
@@ -62,20 +62,25 @@ namespace TP.ExDM.FunctionalProgramming
       Assert.IsTrue(_testResult);
     }
 
-    [TestMethod]
-    public void LambdaSyntaxTest()
-    {
-      const int _length = 10000;
-      Random _newRandom = new Random();
-      int[] _buffer = new int[_length];
-      for (int i = 0; i < _length; i++)
-        _buffer[i] = _newRandom.Next(0, 100);
-      int _count = _buffer.Count((int x) => { return x >= 50; });
-      const int _tolerance = 130;
-      Assert.IsTrue(_count > _length / 2 - _tolerance && _count < _length / 2 + _tolerance, $"{nameof(_count)}={_count}");
-    }
+        [TestMethod]
+        public void LambdaSyntaxTest()
+        {
+            const int _length = 10000;
 
-    [TestMethod]
+            int[] _buffer = Enumerable
+              .Range(0, _length)
+              .Select(index => index % 2 == 0 ? 49 : 50)
+              .ToArray();
+
+            int _count = _buffer.Count((int x) =>
+            {
+                return x >= 50;
+            });
+
+            Assert.AreEqual(_length / 2, _count, $"{nameof(_count)}={_count}");
+        }
+
+        [TestMethod]
     public void DelegateVsExpressionTest()
     {
       //delegate


### PR DESCRIPTION
This pull request fixes issue #443.

The LambdaSyntaxTest previously used Random to generate test data. Because of that, the number of values greater than or equal to 50 could occasionally fall outside the expected tolerance, causing the test to fail randomly.

The test data is now deterministic. The buffer contains exactly half values below 50 and half values greater than or equal to 50. This keeps the purpose of the test, which is to verify the lambda expression used by Count, while removing the random behavior.