### PR TITLE
Add constructor and property injection to Catalog

### DIFF
--- a/ExDataManagement/FunctionalProgramming/FunctionalProgramming.UnitTest/FunctionalProgramming.UnitTest.sln
+++ b/ExDataManagement/FunctionalProgramming/FunctionalProgramming.UnitTest/FunctionalProgramming.UnitTest.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.14.36518.9 d17.14
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FunctionalProgramming.UnitTest", "FunctionalProgramming.UnitTest.csproj", "{0807FE4E-778F-E5B9-C5A5-46EEC4C674E4}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{0807FE4E-778F-E5B9-C5A5-46EEC4C674E4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0807FE4E-778F-E5B9-C5A5-46EEC4C674E4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0807FE4E-778F-E5B9-C5A5-46EEC4C674E4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0807FE4E-778F-E5B9-C5A5-46EEC4C674E4}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {3D551006-5C46-4FA8-83C0-F8211A49DE90}
+	EndGlobalSection
+EndGlobal

--- a/ExDataManagement/StructuralData/StructuralData/LINQ to object/Catalog.cs
+++ b/ExDataManagement/StructuralData/StructuralData/LINQ to object/Catalog.cs
@@ -15,15 +15,29 @@ using TP.ExDM.StructuralData.Data;
 
 namespace TP.ExDM.StructuralData.LINQ_to_object
 {
-  /// <summary>
-  /// Class Catalog.
-  /// Implements the <see cref="System.Data.DataSet" />
-  /// </summary>
-  public partial class Catalog
-  {
-    //TODO ExDM Add DI to the Catalog #385
-    public void AddContent(IEnumerable<IPerson> persons)
+    /// <summary>
+    /// Class Catalog.
+    /// Implements the <see cref="System.Data.DataSet" />
+    /// </summary>
+    public partial class Catalog
     {
+        // Added constructor injection and property injection for issue #385.
+
+        
+
+        public Catalog(IEnumerable<IPerson> persons)
+        {
+            AddContent(persons);
+        }
+
+        public IEnumerable<IPerson> Content
+        {
+            set => AddContent(value);
+        }
+
+        public void AddContent(IEnumerable<IPerson> persons)
+        {
+            
       foreach (IPerson _item in persons)
       {
         PersonRow _newPersonROw = Person.AddPersonRow(_item.FirstName, _item.LastName, _item.Age);

--- a/Saída-Compilação.txt
+++ b/Saída-Compilação.txt
@@ -1,0 +1,3 @@
+﻿A construção começou em 14:49...
+========== Compilação: 0 bem-sucedida, 0 com falha, 11 atualizada, 0 ignorada ==========
+========== Compilação concluído às 14:49 e levou 00,156 segundos ==========


### PR DESCRIPTION
This pull request addresses issue #385.

Constructor injection and property injection were added to the Catalog class as alternative ways of providing the collection of IPerson objects.

The existing AddContent method was kept, so the previous method injection approach remains available.